### PR TITLE
support for forcing in-memory caching and providing credentials in environment variables

### DIFF
--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -33,6 +33,7 @@ from b2sdk.version import VERSION as b2sdk_version
 from b2sdk.v1 import (
     parse_sync_folder,
     AuthInfoCache,
+    InMemoryCache,
     B2Api,
     B2Http,
     B2RawApi,
@@ -44,6 +45,7 @@ from b2sdk.v1 import (
     DownloadDestLocalFile,
     FileVersionInfo,
     SqliteAccountInfo,
+    InMemoryAccountInfo,
     ScanPoliciesManager,
     DEFAULT_SCAN_MANAGER,
 )
@@ -63,6 +65,9 @@ B2_APPLICATION_KEY_ENV_VAR = 'B2_APPLICATION_KEY'
 # Optional Env variable to use for adding custom string to the User Agent
 B2_USER_AGENT_APPEND_ENV_VAR = 'B2_USER_AGENT_APPEND'
 
+B2_USE_INMEMORY_ACCOUNTINFO_ENV_VAR = 'B2_USE_INMEMORY_ACCOUNTINFO'
+AUTHORIZE_ACCOUNT_CMD_NAME = 'authorize-account'
+
 # Enable to get 0.* behavior in the command-line tool.
 # Disable for 1.* behavior.
 VERSION_0_COMPATIBILITY = False
@@ -80,6 +85,8 @@ DOC_STRING_DATA = dict(
     B2_APPLICATION_KEY_ID_ENV_VAR=B2_APPLICATION_KEY_ID_ENV_VAR,
     B2_APPLICATION_KEY_ENV_VAR=B2_APPLICATION_KEY_ENV_VAR,
     B2_USER_AGENT_APPEND_ENV_VAR=B2_USER_AGENT_APPEND_ENV_VAR,
+    B2_USE_INMEMORY_ACCOUNTINFO_ENV_VAR=B2_USE_INMEMORY_ACCOUNTINFO_ENV_VAR,
+    AUTHORIZE_ACCOUNT_CMD_NAME=AUTHORIZE_ACCOUNT_CMD_NAME,
 )
 
 
@@ -126,6 +133,9 @@ class Command(object):
 
     # The registry for the subcommands, should be reinitialized  in subclass
     subcommands_registry = None
+
+    # set to False for commands not requiring b2 authentication
+    REQUIRES_AUTH = True
 
     def __init__(self, console_tool):
         self.console_tool = console_tool
@@ -198,7 +208,17 @@ class Command(object):
 
     @classmethod
     def _setup_parser(cls, parser):
-        pass
+        if cls.REQUIRES_AUTH:
+            cls._environment_parser_args(parser)
+
+    @classmethod
+    def _environment_parser_args(cls, parser):
+        """Add arguments for establishing dev/staging/production realm for authentication.
+        This has to be called at the end of "_setup_parser", because of https://bugs.python.org/issue22363"""
+        realm_group = parser.add_mutually_exclusive_group()
+        realm_group.add_argument('--dev', action='store_true', help=argparse.SUPPRESS)
+        realm_group.add_argument('--staging', action='store_true', help=argparse.SUPPRESS)
+        realm_group.add_argument('--environment', help=argparse.SUPPRESS)
 
     @classmethod
     def _parse_file_infos(cls, args_info):
@@ -242,6 +262,16 @@ class B2(Command):
     """
     This program provides command-line access to the B2 service.
 
+    There are two flows of authorization:
+    * call {NAME} {AUTHORIZE_ACCOUNT_CMD_NAME} and have the credentials cached in sqlite
+    * set {B2_APPLICATION_KEY_ID_ENV_VAR} and {B2_APPLICATION_KEY_ENV_VAR} environment
+      variables when running this program
+
+    Setting environment variable {B2_USE_INMEMORY_ACCOUNTINFO_ENV_VAR} to 1
+    will cause authorization information to be cached in memory only, so it's
+    only possible to use this program with {B2_APPLICATION_KEY_ID_ENV_VAR} and
+    {B2_APPLICATION_KEY_ENV_VAR} environment variables then.
+
     The environment variable {B2_ACCOUNT_INFO_ENV_VAR} specifies the sqlite
     file to use for caching authentication information.
     The default file to use is: {B2_ACCOUNT_INFO_DEFAULT_FILE}
@@ -258,6 +288,8 @@ class B2(Command):
     A string provided via an optional environment variable {B2_USER_AGENT_APPEND_ENV_VAR}
     will be appended to the User-Agent.
     """
+
+    REQUIRES_AUTH = False
 
     subcommands_registry = ClassRegistry()
 
@@ -292,26 +324,32 @@ class AuthorizeAccount(Command):
 
     Stores an account auth token in {B2_ACCOUNT_INFO_DEFAULT_FILE} by default,
     or the file specified by the {B2_ACCOUNT_INFO_ENV_VAR} environment variable.
+    Unless {B2_USE_INMEMORY_ACCOUNTINFO_ENV_VAR} environment variable is equal to 1,
+    then the auth token is not stored and using {B2_APPLICATION_KEY_ID_ENV_VAR} and
+    {B2_APPLICATION_KEY_ENV_VAR} is necessary.
 
     Requires capability: listBuckets
     """
 
     FORBID_LOGGING_ARGUMENTS = True
+    REQUIRES_AUTH = False
+
+    @classmethod
+    def name_and_alias(cls):
+        alias = None if '-' not in AUTHORIZE_ACCOUNT_CMD_NAME else AUTHORIZE_ACCOUNT_CMD_NAME.replace('-', '_')
+        return AUTHORIZE_ACCOUNT_CMD_NAME, alias
 
     @classmethod
     def _setup_parser(cls, parser):
-        realm_group = parser.add_mutually_exclusive_group()
-        realm_group.add_argument('--dev', action='store_true', help=argparse.SUPPRESS)
-        realm_group.add_argument('--staging', action='store_true', help=argparse.SUPPRESS)
-        realm_group.add_argument('--environment', help=argparse.SUPPRESS)
-
         parser.add_argument('applicationKeyId', nargs='?')
         parser.add_argument('applicationKey', nargs='?')
+
+        cls._environment_parser_args(parser)
 
     def run(self, args):
         # Handle internal options for testing inside Backblaze.
         # These are not documented in the usage string.
-        realm = self._get_realm(args)
+        realm = self.get_realm(args)
 
         url = self.api.account_info.REALM_URLS.get(realm, realm)
         self._print('Using %s' % url)
@@ -356,7 +394,7 @@ class AuthorizeAccount(Command):
             return 1
 
     @classmethod
-    def _get_realm(cls, args):
+    def get_realm(cls, args):
         if args.dev:
             return 'dev'
         if args.staging:
@@ -380,6 +418,7 @@ class CancelAllUnfinishedLargeFiles(Command):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('bucketName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         bucket = self.api.get_bucket_by_name(args.bucketName)
@@ -403,6 +442,7 @@ class CancelLargeFile(Command):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('fileId')
+        super()._setup_parser(parser)
 
     def run(self, args):
         self.api.cancel_large_file(args.fileId)
@@ -416,6 +456,8 @@ class ClearAccount(Command):
     Erases everything in {B2_ACCOUNT_INFO_DEFAULT_FILE}.  Location
     of file can be overridden by setting {B2_ACCOUNT_INFO_ENV_VAR}.
     """
+
+    REQUIRES_AUTH = False
 
     def run(self, args):
         self.api.account_info.clear()
@@ -458,6 +500,7 @@ class CopyFileById(Command):
         parser.add_argument('sourceFileId')
         parser.add_argument('destinationBucketName')
         parser.add_argument('b2FileName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         file_infos = None
@@ -503,6 +546,7 @@ class CreateBucket(Command):
         parser.add_argument('--lifecycleRules', type=json.loads)
         parser.add_argument('bucketName')
         parser.add_argument('bucketType')
+        super()._setup_parser(parser)
 
     def run(self, args):
         bucket = self.api.create_bucket(
@@ -547,6 +591,7 @@ class CreateKey(Command):
         parser.add_argument('--duration', type=int)
         parser.add_argument('keyName')
         parser.add_argument('capabilities', type=parse_comma_separated_list)
+        super()._setup_parser(parser)
 
     def run(self, args):
         # Translate the bucket name into a bucketId
@@ -580,6 +625,7 @@ class DeleteBucket(Command):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('bucketName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         bucket = self.api.get_bucket_by_name(args.bucketName)
@@ -604,6 +650,7 @@ class DeleteFileVersion(Command):
     def _setup_parser(cls, parser):
         parser.add_argument('fileName', nargs='?')
         parser.add_argument('fileId')
+        super()._setup_parser(parser)
 
     def run(self, args):
         if args.fileName is not None:
@@ -631,6 +678,7 @@ class DeleteKey(Command):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('applicationKeyId')
+        super()._setup_parser(parser)
 
     def run(self, args):
         response = self.api.delete_key(application_key_id=args.applicationKeyId)
@@ -655,6 +703,7 @@ class DownloadFileById(Command):
         parser.add_argument('--noProgress', action='store_true')
         parser.add_argument('fileId')
         parser.add_argument('localFileName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         progress_listener = make_progress_listener(args.localFileName, args.noProgress)
@@ -682,6 +731,7 @@ class DownloadFileByName(Command):
         parser.add_argument('bucketName')
         parser.add_argument('b2FileName')
         parser.add_argument('localFileName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         bucket = self.api.get_bucket_by_name(args.bucketName)
@@ -698,6 +748,8 @@ class GetAccountInfo(Command):
     Shows the account ID, key, auth token, URLs, and what capabilities
     the current application keys has.
     """
+
+    REQUIRES_AUTH = False
 
     def run(self, args):
         account_info = self.api.account_info
@@ -737,6 +789,7 @@ class GetBucket(Command):
     def _setup_parser(cls, parser):
         parser.add_argument('--showSize', action='store_true')
         parser.add_argument('bucketName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         # This always wants up-to-date info, so it does not use
@@ -778,6 +831,7 @@ class GetFileInfo(Command):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('fileId')
+        super()._setup_parser(parser)
 
     def run(self, args):
         response = self.api.get_file_info(args.fileId)
@@ -806,6 +860,7 @@ class GetDownloadAuth(Command):
         parser.add_argument('--prefix', default='')
         parser.add_argument('--duration', type=int, default=86400)
         parser.add_argument('bucketName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         bucket = self.api.get_bucket_by_name(args.bucketName)
@@ -838,6 +893,7 @@ class GetDownloadUrlWithAuth(Command):
         parser.add_argument('--duration', type=int, default=86400)
         parser.add_argument('bucketName')
         parser.add_argument('fileName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         bucket = self.api.get_bucket_by_name(args.bucketName)
@@ -862,6 +918,7 @@ class HideFile(Command):
     def _setup_parser(cls, parser):
         parser.add_argument('bucketName')
         parser.add_argument('fileName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         bucket = self.api.get_bucket_by_name(args.bucketName)
@@ -889,6 +946,7 @@ class ListBuckets(Command):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('--json', action='store_true')
+        super()._setup_parser(parser)
 
     def run(self, args):
         buckets = self.api.list_buckets()
@@ -928,6 +986,7 @@ class ListKeys(Command):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('--long', action='store_true')
+        super()._setup_parser(parser)
 
     def __init__(self, console_tool):
         super(ListKeys, self).__init__(console_tool)
@@ -1007,6 +1066,7 @@ class ListParts(Command):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('largeFileId')
+        super()._setup_parser(parser)
 
     def run(self, args):
         for part in self.api.list_parts(args.largeFileId):
@@ -1026,6 +1086,7 @@ class ListUnfinishedLargeFiles(Command):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('bucketName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         bucket = self.api.get_bucket_by_name(args.bucketName)
@@ -1074,6 +1135,7 @@ class Ls(Command):
         parser.add_argument('--recursive', action='store_true')
         parser.add_argument('bucketName')
         parser.add_argument('folderName', nargs='?')
+        super()._setup_parser(parser)
 
     def run(self, args):
         if args.folderName is None:
@@ -1115,6 +1177,7 @@ class MakeUrl(Command):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('fileId')
+        super()._setup_parser(parser)
 
     def run(self, args):
         self._print(self.api.get_download_url_for_fileid(args.fileId))
@@ -1132,6 +1195,7 @@ class MakeFriendlyUrl(Command):
     def _setup_parser(cls, parser):
         parser.add_argument('bucketName')
         parser.add_argument('fileName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         self._print(self.api.get_download_url_for_file_name(args.bucketName, args.fileName))
@@ -1298,6 +1362,7 @@ class Sync(Command):
         del_keep_group = parser.add_mutually_exclusive_group()
         del_keep_group.add_argument('--delete', action='store_true')
         del_keep_group.add_argument('--keepDays', type=float, metavar='DAYS')
+        super()._setup_parser(parser)
 
     def run(self, args):
         policies_manager = self.get_policies_manager_from_args(args)
@@ -1398,6 +1463,7 @@ class UpdateBucket(Command):
         parser.add_argument('--lifecycleRules', type=json.loads)
         parser.add_argument('bucketName')
         parser.add_argument('bucketType')
+        super()._setup_parser(parser)
 
     def run(self, args):
         bucket = self.api.get_bucket_by_name(args.bucketName)
@@ -1454,6 +1520,7 @@ class UploadFile(Command):
         parser.add_argument('bucketName')
         parser.add_argument('localFilePath')
         parser.add_argument('b2FileName')
+        super()._setup_parser(parser)
 
     def run(self, args):
         file_infos = self._parse_file_infos(args.info)
@@ -1488,6 +1555,8 @@ class Version(Command):
     Prints the version number of this tool.
     """
 
+    REQUIRES_AUTH = False
+
     def run(self, args):
         self._print('b2 command line tool, version', VERSION)
         return 0
@@ -1518,10 +1587,16 @@ class ConsoleTool(object):
         self._setup_logging(args, command, argv)
 
         try:
+            auth_ret = self.authorize_from_env(command_class, args)
+            if auth_ret:
+                return auth_ret
             return command.run(args)
         except MissingAccountData as e:
             logger.exception('ConsoleTool missing account data error')
-            self._print_stderr('ERROR: %s  Use: %s authorize-account' % (str(e), NAME))
+            self._print_stderr('ERROR: %s  Use: %s %s or provide auth data with "%s" and "%s"'
+                               ' environment variables' % (
+                                   str(e), NAME, AUTHORIZE_ACCOUNT_CMD_NAME, B2_APPLICATION_KEY_ID_ENV_VAR,
+                                   B2_APPLICATION_KEY_ENV_VAR))
             return 1
         except B2Error as e:
             logger.exception('ConsoleTool command error')
@@ -1534,6 +1609,23 @@ class ConsoleTool(object):
         except Exception:
             logger.exception('ConsoleTool unexpected exception')
             raise
+
+    def authorize_from_env(self, command_class, args):
+        if not command_class.REQUIRES_AUTH:
+            return 0
+        if B2_APPLICATION_KEY_ID_ENV_VAR not in os.environ:
+            return 0
+
+        key_id = os.environ[B2_APPLICATION_KEY_ID_ENV_VAR]
+        key = os.environ.setdefault(B2_APPLICATION_KEY_ENV_VAR, '')
+
+        if self.api.account_info.check_current_credentials(key_id, key, AuthorizeAccount.get_realm(args)):
+            return 0
+
+        args.applicationKeyId = key_id
+        args.applicationKey = key
+
+        return AuthorizeAccount(self).run(args)
 
     def _print(self, *args, **kwargs):
         print(*args, file=self.stdout, **kwargs)
@@ -1613,8 +1705,12 @@ class InvalidArgument(B2Error):
 
 
 def main():
-    info = SqliteAccountInfo()
-    cache = AuthInfoCache(info)
+    if os.environ.get(B2_USE_INMEMORY_ACCOUNTINFO_ENV_VAR) == '1':
+        info = InMemoryAccountInfo()
+        cache = InMemoryCache()
+    else:
+        info = SqliteAccountInfo()
+        cache = AuthInfoCache(info)
     raw_api = B2RawApi(B2Http(user_agent_append=os.environ.get(B2_USER_AGENT_APPEND_ENV_VAR)))
     b2_api = B2Api(info, cache=cache, raw_api=raw_api)
     ct = ConsoleTool(b2_api=b2_api, stdout=sys.stdout, stderr=sys.stderr)

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -148,6 +148,63 @@ class TestConsoleTool(TestBase):
             0,
         )
 
+    def test_create_key_with_authorization_from_env_vars(self):
+        # Initial condition
+        assert self.account_info.get_account_auth_token() is None
+
+        # Authorize an account with a good api key.
+
+        # Setting up environment variables
+        with mock.patch.dict(
+            'os.environ', {
+                B2_APPLICATION_KEY_ID_ENV_VAR: self.account_id,
+                B2_APPLICATION_KEY_ENV_VAR: self.master_key,
+            }
+        ):
+            assert B2_APPLICATION_KEY_ID_ENV_VAR in os.environ
+            assert B2_APPLICATION_KEY_ENV_VAR in os.environ
+
+            # The first time we're running on this cache there will be output from the implicit "authorize-account" call
+            self._run_command(
+                ['create-key', 'key1', 'listBuckets,listKeys'],
+                'Using http://production.example.com\n'
+                'appKeyId0 appKey0\n',
+                '',
+                0,
+            )
+
+            # The second time "authorize-account" is not called
+            self._run_command(
+                ['create-key', 'key1', 'listBuckets,listKeys,writeKeys'],
+                'appKeyId1 appKey1\n',
+                '',
+                0,
+            )
+
+            with mock.patch.dict(
+                    'os.environ', {
+                        B2_APPLICATION_KEY_ID_ENV_VAR: 'appKeyId1',
+                        B2_APPLICATION_KEY_ENV_VAR: 'appKey1',
+                    }
+            ):
+                # "authorize-account" is called when the key changes
+                self._run_command(
+                    ['create-key', 'key1', 'listBuckets,listKeys'],
+                    'Using http://production.example.com\n'
+                    'appKeyId2 appKey2\n',
+                    '',
+                    0,
+                )
+
+                # "authorize-account" is also called when the realm changes
+                self._run_command(
+                    ['create-key', 'key1', 'listBuckets,listKeys', '--environment', 'http://custom.example.com'],
+                    'Using http://custom.example.com\n'
+                    'appKeyId3 appKey3\n',
+                    '',
+                    0,
+                )
+
     def test_authorize_key_without_list_buckets(self):
         self._authorize_account()
 


### PR DESCRIPTION
depends on https://github.com/reef-technologies/b2-sdk-python/pull/113

**README/help changes**
New features are described in command help texts, but not in the main README, because it didn't seem like such a good idea to go into this much details in it. I can add them though.

**Cache classes**
The already existsing classes `InMemoryAccountInfo` and `InMemoryCache` seem to do their job fine. The only problem I noticed is the method: `get_bucket_name_or_none_from_allowed` - it seems to work differently for 
`InMemoryAccountInfo` and `SqliteAccountInfo` - but here's the trick, for `SqliteAccountInfo` it won't work - it's a piece of not working dead code. Should this be removed?

**Subparsers**
I added the possibility to provide `--dev/--staging/--environment=...` to each CLI Command that can authorize implicitly, but I did it "by hand" instead of using "subparsers" - this approach seemed more readable.

**SDK version**
master of this repo cannot be used with the master of SDK repo (at least according to `requirements.txt`) - Is there a schedule saying when the CLI will start using SDK 1.3.0? That's an issue here because this PR depends on a PR in SDK.
