### PR TITLE
support for providing credentials in environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* Option to automatically authorize account when running commands other than `authorize-account` via 
+  `B2_APPLICATION_KEY_ID` and `B2_APPLICATION_KEY` env vars
+
 ### Changed
 * Improve setup and teardown for the integration tests
 * Use setuptools-scm for versioning

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -250,9 +250,10 @@ class B2(Command):
     This program provides command-line access to the B2 service.
 
     There are two flows of authorization:
-    * call {NAME} authorize-account and have the credentials cached in sqlite
-    * set {B2_APPLICATION_KEY_ID_ENV_VAR} and {B2_APPLICATION_KEY_ENV_VAR} environment
-    variables when running this program
+
+    * call ``{NAME}`` authorize-account and have the credentials cached in sqlite
+    * set ``{B2_APPLICATION_KEY_ID_ENV_VAR}`` and ``{B2_APPLICATION_KEY_ENV_VAR}`` environment
+      variables when running this program
 
     The environment variable ``{B2_ACCOUNT_INFO_ENV_VAR}`` specifies the sqlite
     file to use for caching authentication information.
@@ -1657,11 +1658,19 @@ class ConsoleTool(object):
     def authorize_from_env(self, command_class):
         if not command_class.REQUIRES_AUTH:
             return 0
-        if B2_APPLICATION_KEY_ID_ENV_VAR not in os.environ:
+
+        key_id = os.environ.get(B2_APPLICATION_KEY_ID_ENV_VAR)
+        key = os.environ.get(B2_APPLICATION_KEY_ENV_VAR)
+
+        if key_id is None and key is None:
             return 0
 
-        key_id = os.environ[B2_APPLICATION_KEY_ID_ENV_VAR]
-        key = os.environ.get(B2_APPLICATION_KEY_ENV_VAR, '')
+        if (key_id is None) or (key is None):
+            self._print_stderr(
+                'Please provide both "%s" and "%s" environment variables or none of them' %
+                (B2_APPLICATION_KEY_ENV_VAR, B2_APPLICATION_KEY_ID_ENV_VAR)
+            )
+            return 1
         realm = os.environ.get(B2_ENVIRONMENT_ENV_VAR, 'production')
 
         if self.api.account_info.is_same_key(key_id, realm):

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -656,7 +656,6 @@ class DeleteKey(Command):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('applicationKeyId')
-        super()._setup_parser(parser)
 
     def run(self, args):
         response = self.api.delete_key(application_key_id=args.applicationKeyId)
@@ -681,7 +680,6 @@ class DownloadFileById(Command):
         parser.add_argument('--noProgress', action='store_true')
         parser.add_argument('fileId')
         parser.add_argument('localFileName')
-        super()._setup_parser(parser)
 
     def run(self, args):
         progress_listener = make_progress_listener(args.localFileName, args.noProgress)

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -81,7 +81,7 @@ DOC_STRING_DATA = dict(
     B2_APPLICATION_KEY_ID_ENV_VAR=B2_APPLICATION_KEY_ID_ENV_VAR,
     B2_APPLICATION_KEY_ENV_VAR=B2_APPLICATION_KEY_ENV_VAR,
     B2_USER_AGENT_APPEND_ENV_VAR=B2_USER_AGENT_APPEND_ENV_VAR,
-    B2_ENVIRONMENT_ENV_VAR=B2_ENVIRONMENT_ENV_VAR
+    B2_ENVIRONMENT_ENV_VAR=B2_ENVIRONMENT_ENV_VAR,
 )
 
 
@@ -252,7 +252,7 @@ class B2(Command):
     There are two flows of authorization:
     * call {NAME} authorize-account and have the credentials cached in sqlite
     * set {B2_APPLICATION_KEY_ID_ENV_VAR} and {B2_APPLICATION_KEY_ENV_VAR} environment
-      variables when running this program
+    variables when running this program
 
     The environment variable ``{B2_ACCOUNT_INFO_ENV_VAR}`` specifies the sqlite
     file to use for caching authentication information.

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1581,7 +1581,7 @@ class ConsoleTool(object):
         key = os.environ.get(B2_APPLICATION_KEY_ENV_VAR, '')
         realm = os.environ.get(B2_ENVIRONMENT_ENV_VAR, 'production')
 
-        if self.api.account_info.check_current_credentials(key_id, key, realm):
+        if self.api.account_info.is_same_key(key_id, realm):
             return 0
 
         return AuthorizeAccount(self).authorize(key_id, key, realm)

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -537,7 +537,7 @@ def account_test(b2_tool, bucket_name):
     bucket_name = b2_tool.bucket_name_prefix + '-' + random_hex(8)
     b2_tool.should_fail(
         ['create-bucket', bucket_name, 'allPrivate'],
-        r'ERROR: Missing account data: \'NoneType\' object is not subscriptable  '
+        r'ERROR: Missing account data: \'NoneType\' object is not subscriptable (\(key 0\) )? '
         r'Use: b2 authorize-account or provide auth data with "B2_APPLICATION_KEY_ID" and '
         r'"B2_APPLICATION_KEY" environment variables'
     )

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -538,7 +538,7 @@ def account_test(b2_tool, bucket_name):
     b2_tool.should_fail(
         ['create-bucket', bucket_name, 'allPrivate'],
         r'ERROR: Missing account data: \'NoneType\' object is not subscriptable (\(key 0\) )? '
-        r'Use: b2 authorize-account or provide auth data with "B2_APPLICATION_KEY_ID" and '
+        r'Use: b2(\.exe)? authorize-account or provide auth data with "B2_APPLICATION_KEY_ID" and '
         r'"B2_APPLICATION_KEY" environment variables'
     )
     os.remove(new_creds)

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -527,6 +527,36 @@ def account_test(b2_tool, bucket_name):
     b2_tool.should_succeed(['authorize-account', b2_tool.account_id, b2_tool.application_key])
     tearDown_envvar_test('B2_ACCOUNT_INFO')
 
+    # Testing (B2_APPLICATION_KEY, B2_APPLICATION_KEY_ID) for commands other than authorize-account
+    new_creds = os.path.join(tempfile.gettempdir(), 'b2_account_info')
+    setup_envvar_test('B2_ACCOUNT_INFO', new_creds)
+    os.remove(new_creds)
+
+    # first, let's make sure "create-bucket" doesn't work without auth data - i.e. that the sqlite file hs been
+    # successfully removed
+    bucket_name = b2_tool.bucket_name_prefix + '-' + random_hex(8)
+    b2_tool.should_fail(
+        ['create-bucket', bucket_name, 'allPrivate'],
+        r'ERROR: Missing account data: \'NoneType\' object is not subscriptable  '
+        r'Use: b2 authorize-account or provide auth data with "B2_APPLICATION_KEY_ID" and '
+        r'"B2_APPLICATION_KEY" environment variables'
+    )
+    os.remove(new_creds)
+
+    # then, let's see that auth data from env vars works
+    os.environ['B2_APPLICATION_KEY'] = os.environ['B2_TEST_APPLICATION_KEY']
+    os.environ['B2_APPLICATION_KEY_ID'] = os.environ['B2_TEST_APPLICATION_KEY_ID']
+
+    bucket_name = b2_tool.bucket_name_prefix + '-' + random_hex(8)
+    b2_tool.should_succeed(['create-bucket', bucket_name, 'allPrivate'])
+    b2_tool.should_succeed(['delete-bucket', bucket_name])
+    assert os.path.exists(new_creds), 'sqlite file not created'
+
+    os.environ.pop('B2_APPLICATION_KEY')
+    os.environ.pop('B2_APPLICATION_KEY_ID')
+
+    tearDown_envvar_test('B2_ACCOUNT_INFO')
+
 
 def file_version_summary(list_of_files):
     """

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -555,6 +555,21 @@ def account_test(b2_tool, bucket_name):
     os.environ.pop('B2_APPLICATION_KEY')
     os.environ.pop('B2_APPLICATION_KEY_ID')
 
+    # last, let's see that providing only one of the env vars results in a failure
+    os.environ['B2_APPLICATION_KEY'] = os.environ['B2_TEST_APPLICATION_KEY']
+    b2_tool.should_fail(
+        ['create-bucket', bucket_name, 'allPrivate'],
+        r'Please provide both "B2_APPLICATION_KEY" and "B2_APPLICATION_KEY_ID" environment variables or none of them'
+    )
+    os.environ.pop('B2_APPLICATION_KEY')
+
+    os.environ['B2_APPLICATION_KEY_ID'] = os.environ['B2_TEST_APPLICATION_KEY_ID']
+    b2_tool.should_fail(
+        ['create-bucket', bucket_name, 'allPrivate'],
+        r'Please provide both "B2_APPLICATION_KEY" and "B2_APPLICATION_KEY_ID" environment variables or none of them'
+    )
+    os.environ.pop('B2_APPLICATION_KEY_ID')
+
     tearDown_envvar_test('B2_ACCOUNT_INFO')
 
 


### PR DESCRIPTION
depends on reef-technologies/b2-sdk-python#113

**README/help changes**
New features are described in command help texts, but not in the main README, because it didn't seem like such a good idea to go into this much details in it. I can add them though.

**Cache classes**
The already existsing classes InMemoryAccountInfo and InMemoryCache seem to do their job fine. The only problem I noticed is the method: get_bucket_name_or_none_from_allowed - it seems to work differently for
InMemoryAccountInfo and SqliteAccountInfo - but here's the trick, for SqliteAccountInfo it won't work - it's a piece of not working dead code. Should this be removed?

**parent parser**
I added the possibility to provide --dev/--staging/--environment=... to each CLI Command that can authorize implicitly, but I did it "by hand" instead of using `parents` in `get_parser` - this approach seemed more readable.

**SDK version**
master of this repo cannot be used with the master of SDK repo (at least according to requirements.txt) - Is there a schedule saying when the CLI will start using SDK 1.3.0? That's an issue here because this PR depends on a PR in SDK.