### PR TITLE
Facilitate for arrow's bug in parsing millis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fix for the Windows bundled version
 * Fix docs autogen
+* Facilitate for a change in arrow's `.format`
 
 ## [2.1.0] - 2020-11-03
 

--- a/b2/arg_parser.py
+++ b/b2/arg_parser.py
@@ -84,7 +84,7 @@ def parse_millis_from_float_timestamp(s):
     """
     Parse timestamp, e.g. 1367900664 or 1367900664.152
     """
-    return int(arrow.get(float(s)).format('XSSS'))
+    return round(arrow.get(float(s)).float_timestamp * 1000)
 
 
 def parse_range(s):


### PR DESCRIPTION
There's probably a bug in arrow: arrow-py/arrow#933