### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,31 @@ jobs:
         run: python -m pip install --upgrade nox pip setuptools
       - name: Build the distribution
         run: nox -vs build
-  test:
+  cleanup_buckets:
     needs: lint
+    env:
+      B2_TEST_APPLICATION_KEY: ${{ secrets.B2_TEST_APPLICATION_KEY }}
+      B2_TEST_APPLICATION_KEY_ID: ${{ secrets.B2_TEST_APPLICATION_KEY_ID }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}  # TODO: skip this whole job instead
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ env.PYTHON_DEFAULT_VERSION }}
+        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}  # TODO: skip this whole job instead
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
+          cache: "pip"
+      - name: Install dependencies
+        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}  # TODO: skip this whole job instead
+        run: python -m pip install --upgrade nox pip setuptools
+      - name: Find and remove old buckets
+        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}  # TODO: skip this whole job instead
+        run: nox -vs cleanup_buckets
+  test:
+    needs: cleanup_buckets
     env:
       B2_TEST_APPLICATION_KEY: ${{ secrets.B2_TEST_APPLICATION_KEY }}
       B2_TEST_APPLICATION_KEY_ID: ${{ secrets.B2_TEST_APPLICATION_KEY_ID }}
@@ -79,7 +102,7 @@ jobs:
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
         run: nox -vs integration -- --cleanup
   test-linux-bundle:
-    needs: lint
+    needs: cleanup_buckets
     env:
       B2_TEST_APPLICATION_KEY: ${{ secrets.B2_TEST_APPLICATION_KEY }}
       B2_TEST_APPLICATION_KEY_ID: ${{ secrets.B2_TEST_APPLICATION_KEY_ID }}
@@ -111,7 +134,7 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
   test-macos-and-windows-bundle:
-    needs: lint
+    needs: cleanup_buckets
     env:
       B2_TEST_APPLICATION_KEY: ${{ secrets.B2_TEST_APPLICATION_KEY }}
       B2_TEST_APPLICATION_KEY_ID: ${{ secrets.B2_TEST_APPLICATION_KEY_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,12 @@ This version is pinned strictly to `b2-sdk-python==1.17.0` for the same reason.
 * Add `--skip-hash-verification` parameter
 * Add `replication-status` command
 
-### Changed
-* Limit number of workers for integration tests to 4
-* Make integration tests remove buckets only based on name, not based on creation time
-
-### Fixed
-* Fix integration tests (replication) due to internal B2 API change
-* Fix leaking buckets in integration tests
-
 ### Infrastructure
 * Try not to crash tests due to bucket name collision
+* Fix integration tests (replication) due to internal B2 API change
+* Fix leaking buckets in integration tests
+* Limit number of workers for integration tests to 4
+* Make integration tests remove buckets only based on name, not based on creation time
 
 ## [3.4.0] - 2022-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ This version is pinned strictly to `b2-sdk-python==1.17.0` for the same reason.
 * Add `--skip-hash-verification` parameter
 * Add `replication-status` command
 
+### Changed
+* Limit number of workers for integration tests to 4
+* Make integration tests remove buckets only based on name, not based on creation time
+
+### Fixed
+* Fix integration tests (replication) due to internal B2 API change
+* Fix leaking buckets in integration tests
+
 ### Infrastructure
 * Try not to crash tests due to bucket name collision
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 As in 3.4.0, replication support may be unstable, however no backward-incompatible
 changes are currently planned.
-This version is pinned strictly to `b2-sdk-python==1.17.0` for the same reason.
+This version is pinned strictly to `b2-sdk-python==1.17.3` for the same reason.
 
 ### Added
 * Add `--write-buffer-size` parameter

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -2472,7 +2472,7 @@ class ReplicationStatus(Command):
         super()._setup_parser(parser)
         parser.add_argument('source', metavar='SOURCE_BUCKET_NAME')
         parser.add_argument('--rule', metavar='REPLICATION_RULE_NAME', default=None)
-        parser.add_argument('--destination-profile', required=True)
+        parser.add_argument('--destination-profile')
         parser.add_argument('--dont-scan-destination', action='store_true')
         parser.add_argument(
             '--output-format', default='console', choices=('console', 'json', 'csv')

--- a/noxfile.py
+++ b/noxfile.py
@@ -156,7 +156,8 @@ def integration(session):
     """Run integration tests."""
     install_myself(session)
     session.install(*REQUIREMENTS_TEST)
-    session.run('pytest', '-s', '-x', '-v', '-n', '4', *session.posargs, 'test/integration')
+    #session.run('pytest', '-s', '-x', '-v', '-n', '4', *session.posargs, 'test/integration')
+    session.run('pytest', '-s', '-x', '-v', *session.posargs, 'test/integration')
 
 
 @nox.session(python=PYTHON_VERSIONS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,6 +37,7 @@ REQUIREMENTS_TEST = [
     "pytest-cov==3.0.0",
     'pytest-xdist==2.5.0',
     'filelock==3.6.0',
+    'backoff==2.1.2',
 ]
 REQUIREMENTS_BUILD = ['setuptools>=20.2']
 REQUIREMENTS_BUNDLE = [
@@ -170,6 +171,14 @@ def test(session):
     else:
         session.notify('unit')
         session.notify('integration')
+
+
+@nox.session(python=PYTHON_DEFAULT_VERSION)
+def cleanup_buckets(session):
+    """Remove buckets from previous test runs."""
+    install_myself(session)
+    session.install(*REQUIREMENTS_TEST)
+    session.run('pytest', '-s', '-x', *session.posargs, 'test/integration/cleanup_buckets.py')
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -156,7 +156,7 @@ def integration(session):
     """Run integration tests."""
     install_myself(session)
     session.install(*REQUIREMENTS_TEST)
-    session.run('pytest', '-s', '-x', '-n', '4', *session.posargs, 'test/integration')
+    session.run('pytest', '-s', '-x', '-v', '-n', '4', *session.posargs, 'test/integration')
 
 
 @nox.session(python=PYTHON_VERSIONS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,6 @@ REQUIREMENTS_TEST = [
     "pytest==6.2.5",
     "pytest-cov==3.0.0",
     'pytest-xdist==2.5.0',
-    'filelock==3.6.0',
     'backoff==2.1.2',
 ]
 REQUIREMENTS_BUILD = ['setuptools>=20.2']

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,13 +73,14 @@ def install_myself(session, extras=None):
     if extras:
         arg += '[%s]' % ','.join(extras)
 
+    session.install('-e', arg)
+
     if INSTALL_SDK_FROM:
         cwd = os.getcwd()
         os.chdir(INSTALL_SDK_FROM)
         session.run('pip', 'uninstall', 'b2sdk', '-y')
         session.run('python', 'setup.py', 'develop')
         os.chdir(cwd)
-    session.install('-e', arg)
 
 
 @nox.session(name='format', python=PYTHON_DEFAULT_VERSION)

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,6 @@ import platform
 import subprocess
 
 from glob import glob
-from multiprocessing import cpu_count
 
 import nox
 
@@ -157,9 +156,7 @@ def integration(session):
     """Run integration tests."""
     install_myself(session)
     session.install(*REQUIREMENTS_TEST)
-    session.run(
-        'pytest', '-s', '-n', str(min(cpu_count(), 8) * 5), *session.posargs, 'test/integration'
-    )
+    session.run('pytest', '-s', '-x', '-n', '4', *session.posargs, 'test/integration')
 
 
 @nox.session(python=PYTHON_VERSIONS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arrow>=1.0.2,<2.0.0
-b2sdk==1.17.2
+b2sdk==1.17.3
 docutils==0.16
 idna>=2.2.0; platform_system == 'Java'
 importlib-metadata>=3.3.0; python_version < '3.8'

--- a/test/integration/cleanup_buckets.py
+++ b/test/integration/cleanup_buckets.py
@@ -1,0 +1,16 @@
+######################################################################
+#
+# File: test/integration/cleanup_buckets.py
+#
+# Copyright 2022 Backblaze Inc. All Rights Reserved.
+#
+# License https://www.backblaze.com/using_b2_code.html
+#
+######################################################################
+
+
+def test_cleanup_buckets(b2_api):
+    # this is not a test, but it is intended to be called
+    # via pytest because it reuses fixtures which have everything
+    # set up
+    b2_api.clean_buckets()

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -7,6 +7,8 @@
 # License https://www.backblaze.com/using_b2_code.html
 #
 ######################################################################
+
+import contextlib
 import sys
 
 from os import environ, path
@@ -53,10 +55,8 @@ def realm() -> str:
 def bucket_name(b2_api) -> str:
     bucket = b2_api.create_bucket()
     yield bucket.name
-    try:
+    with contextlib.suppress(BucketIdNotFound):
         b2_api.clean_bucket(bucket)
-    except BucketIdNotFound:
-        pass
 
 
 @pytest.fixture(scope='function')  # , autouse=True)

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -70,7 +70,7 @@ def debug_print_buckets(b2_api):
     finally:
         print('-' * 30)
         print('Buckets after test ' + environ['PYTEST_CURRENT_TEST'])
-        delta = b2_api.print_buckets() - num_buckets
+        delta = b2_api.count_and_print_buckets() - num_buckets
         print(f'DELTA: {delta}')
         print('-' * 30)
 

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -10,14 +10,12 @@
 import sys
 
 from os import environ, path
-from pathlib import Path
-from tempfile import TemporaryDirectory, gettempdir
+from tempfile import TemporaryDirectory
 
 import pytest
 
 from b2sdk.v2 import B2_ACCOUNT_INFO_ENV_VAR, XDG_CONFIG_HOME_ENV_VAR
 from b2sdk.exception import BucketIdNotFound
-from filelock import FileLock
 
 from .helpers import Api, CommandLine, bucket_name_part
 

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -105,12 +105,9 @@ def auto_change_account_info_dir(monkey_patch) -> dir:
 
 
 @pytest.fixture(scope='module')
-def b2_api(
-    application_key_id, application_key, realm, general_bucket_name_prefix,
-    this_run_bucket_name_prefix
-) -> Api:
+def b2_api(application_key_id, application_key, realm, this_run_bucket_name_prefix) -> Api:
     yield Api(
-        application_key_id, application_key, realm, general_bucket_name_prefix,
+        application_key_id, application_key, realm, GENERAL_BUCKET_NAME_PREFIX,
         this_run_bucket_name_prefix
     )
 

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -53,7 +53,12 @@ def realm() -> str:
 
 @pytest.fixture(scope='function')
 def bucket_name(b2_api) -> str:
-    yield b2_api.create_bucket().name
+    bucket = b2_api.create_bucket()
+    yield bucket.name
+    try:
+        b2_api.clean_bucket(bucket)
+    except BucketIdNotFound:
+        pass
 
 
 @pytest.fixture(scope='function')  # , autouse=True)

--- a/test/integration/helpers.py
+++ b/test/integration/helpers.py
@@ -188,6 +188,14 @@ class Api:
                 print('It seems that bucket %s has already been removed' % (bucket.name,))
         print()
 
+    def count_and_print_buckets(self) -> int:
+        buckets = self.api.list_buckets()
+        count = len(buckets)
+        print(f'Total bucket count at {datetime.now()}: {count}')
+        for i, bucket in enumerate(buckets, start=1):
+            print(f'- {i}\t{bucket.name} [{bucket.id_}]')
+        return count
+
 
 def print_text_indented(text):
     """

--- a/test/integration/helpers.py
+++ b/test/integration/helpers.py
@@ -20,16 +20,21 @@ import sys
 import threading
 
 from dataclasses import dataclass
+from datetime import datetime
 from os import environ, linesep, path
 from pathlib import Path
 from tempfile import gettempdir, mkdtemp
 from typing import List, Optional, Union
 
+import backoff
+
+from b2sdk._v3.exception import BucketIdNotFound as v3BucketIdNotFound
 from b2sdk.v2 import ALL_CAPABILITIES, NO_RETENTION_FILE_SETTING, B2Api, Bucket, EncryptionAlgorithm, EncryptionKey, EncryptionMode, EncryptionSetting, InMemoryAccountInfo, InMemoryCache, LegalHold, RetentionMode, SqliteAccountInfo, fix_windows_path_limit
-from b2sdk.v2.exception import BucketIdNotFound, DuplicateBucketName, FileNotPresent
+from b2sdk.v2.exception import BucketIdNotFound, DuplicateBucketName, FileNotPresent, TooManyRequests
 
 from b2.console_tool import Command, current_time_millis
 
+BUCKET_CLEANUP_PERIOD_MILLIS = 0
 ONE_HOUR_MILLIS = 60 * 60 * 1000
 ONE_DAY_MILLIS = ONE_HOUR_MILLIS * 24
 
@@ -98,7 +103,7 @@ class Api:
         OLD_PATTERN = 'test-b2-cli-'
         if bucket.name.startswith(self.general_bucket_name_prefix) or bucket.name.startswith(OLD_PATTERN):  # yapf: disable
             if BUCKET_CREATED_AT_MILLIS in bucket.bucket_info:
-                delete_older_than = current_time_millis() - ONE_HOUR_MILLIS
+                delete_older_than = current_time_millis() - BUCKET_CLEANUP_PERIOD_MILLIS
                 this_bucket_creation_time = bucket.bucket_info[BUCKET_CREATED_AT_MILLIS]
                 if int(this_bucket_creation_time) < delete_older_than:
                     return True, f"this_bucket_creation_time={this_bucket_creation_time} < delete_older_than={delete_older_than}"
@@ -116,9 +121,24 @@ class Api:
                 continue
 
             print('Trying to remove bucket:', bucket.name, 'because', why)
-            self.clean_bucket(bucket)
+            try:
+                self.clean_bucket(bucket)
+            except (BucketIdNotFound, v3BucketIdNotFound):
+                print('It seems that bucket %s has already been removed' % (bucket.name,))
+        buckets = self.api.list_buckets()
+        print('Total bucket count after cleanup:', len(buckets))
+        for bucket in buckets:
+            print(bucket)
 
-    def clean_bucket(self, bucket: Bucket):
+    @backoff.on_exception(
+        backoff.expo,
+        TooManyRequests,
+        max_tries=8,
+    )
+    def clean_bucket(self, bucket: Union[Bucket, str]):
+        if isinstance(bucket, str):
+            bucket = self.api.get_bucket_by_name(bucket)
+
         files_leftover = False
         file_versions = bucket.ls(latest_only=False, recursive=True)
 

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -11,6 +11,7 @@
 
 import base64
 import hashlib
+import itertools
 import json
 import os
 import os.path
@@ -2271,71 +2272,73 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
         ]
     )
 
-    assert replication_status_json == {
-        "replication-one":
-            [
-                {
-                    "count": 1,
-                    "destination_replication_status": None,
-                    "hash_differs": None,
-                    "metadata_differs": None,
-                    "source_has_file_retention": None,
-                    "source_has_hide_marker": None,
-                    "source_has_large_metadata": None,
-                    "source_has_legal_hold": None,
-                    "source_has_sse_c_enabled": None,
-                    "source_replication_status": None,
-                }
-            ],
-        "replication-two":
-            [
-                {
-                    "count": 1,
-                    "destination_replication_status": None,
-                    "hash_differs": None,
-                    "metadata_differs": None,
-                    "source_has_file_retention": False,
-                    "source_has_hide_marker": False,
-                    "source_has_large_metadata": False,
-                    "source_has_legal_hold": True,
-                    "source_has_sse_c_enabled": False,
-                    "source_replication_status": "FAILED"
-                }, {
-                    "count": 1,
-                    "destination_replication_status": None,
-                    "hash_differs": None,
-                    "metadata_differs": None,
-                    "source_has_file_retention": False,
-                    "source_has_hide_marker": False,
-                    "source_has_large_metadata": False,
-                    "source_has_legal_hold": False,
-                    "source_has_sse_c_enabled": False,
-                    "source_replication_status": "FAILED"
-                }, {
-                    "count": 1,
-                    "destination_replication_status": None,
-                    "hash_differs": None,
-                    "metadata_differs": None,
-                    "source_has_file_retention": False,
-                    "source_has_hide_marker": False,
-                    "source_has_large_metadata": False,
-                    "source_has_legal_hold": False,
-                    "source_has_sse_c_enabled": True,
-                    "source_replication_status": None,
-                }, {
-                    "count": 1,
-                    "destination_replication_status": None,
-                    "hash_differs": None,
-                    "metadata_differs": None,
-                    "source_has_file_retention": False,
-                    "source_has_hide_marker": False,
-                    "source_has_large_metadata": False,
-                    "source_has_legal_hold": True,
-                    "source_has_sse_c_enabled": True,
-                    "source_replication_status": None,
-                }
-            ]
-    }
+    assert replication_status_json in [
+        {
+            "replication-one":
+                [
+                    {
+                        "count": 1,
+                        "destination_replication_status": None,
+                        "hash_differs": None,
+                        "metadata_differs": None,
+                        "source_has_file_retention": None,
+                        "source_has_hide_marker": None,
+                        "source_has_large_metadata": None,
+                        "source_has_legal_hold": None,
+                        "source_has_sse_c_enabled": None,
+                        "source_replication_status": None,
+                    }
+                ],
+            "replication-two":
+                [
+                    {
+                        "count": 1,
+                        "destination_replication_status": None,
+                        "hash_differs": None,
+                        "metadata_differs": None,
+                        "source_has_file_retention": False,
+                        "source_has_hide_marker": False,
+                        "source_has_large_metadata": False,
+                        "source_has_legal_hold": True,
+                        "source_has_sse_c_enabled": False,
+                        "source_replication_status": first,
+                    }, {
+                        "count": 1,
+                        "destination_replication_status": None,
+                        "hash_differs": None,
+                        "metadata_differs": None,
+                        "source_has_file_retention": False,
+                        "source_has_hide_marker": False,
+                        "source_has_large_metadata": False,
+                        "source_has_legal_hold": False,
+                        "source_has_sse_c_enabled": False,
+                        "source_replication_status": second,
+                    }, {
+                        "count": 1,
+                        "destination_replication_status": None,
+                        "hash_differs": None,
+                        "metadata_differs": None,
+                        "source_has_file_retention": False,
+                        "source_has_hide_marker": False,
+                        "source_has_large_metadata": False,
+                        "source_has_legal_hold": False,
+                        "source_has_sse_c_enabled": True,
+                        "source_replication_status": None,
+                    }, {
+                        "count": 1,
+                        "destination_replication_status": None,
+                        "hash_differs": None,
+                        "metadata_differs": None,
+                        "source_has_file_retention": False,
+                        "source_has_hide_marker": False,
+                        "source_has_large_metadata": False,
+                        "source_has_legal_hold": True,
+                        "source_has_sse_c_enabled": True,
+                        "source_replication_status": None,
+                    }
+                ]
+        } for first, second in itertools.product(['FAILED', 'PENDING'], ['FAILED', 'PENDING'])
+    ]
 
     b2_api.clean_bucket(source_bucket_name)
 

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -224,7 +224,7 @@ def test_bucket(b2_tool, bucket_name):
     ]
 
 
-def test_key_restrictions(b2_tool, bucket_name):
+def test_key_restrictions(b2_api, b2_tool, bucket_name):
 
     second_bucket_name = b2_tool.generate_bucket_name()
     b2_tool.should_succeed(['create-bucket', second_bucket_name, 'allPublic', *get_bucketinfo()],)
@@ -277,7 +277,7 @@ def test_key_restrictions(b2_tool, bucket_name):
             b2_tool.application_key
         ]
     )
-    b2_tool.should_succeed(['delete-bucket', second_bucket_name])
+    b2_api.clean_bucket(second_bucket_name)
     b2_tool.should_succeed(['delete-key', key_one_id])
     b2_tool.should_succeed(['delete-key', key_two_id])
 
@@ -1017,7 +1017,7 @@ def test_sync_long_path(b2_tool, bucket_name):
         should_equal(['+ ' + long_path], file_version_summary(file_versions))
 
 
-def test_default_sse_b2(b2_tool, bucket_name):
+def test_default_sse_b2(b2_api, b2_tool, bucket_name):
     # Set default encryption via update-bucket
     bucket_info = b2_tool.should_succeed_json(['get-bucket', bucket_name])
     bucket_default_sse = {'mode': 'none'}
@@ -1056,7 +1056,7 @@ def test_default_sse_b2(b2_tool, bucket_name):
         'mode': 'SSE-B2',
     }
     should_equal(second_bucket_default_sse, second_bucket_info['defaultServerSideEncryption'])
-    b2_tool.should_succeed(['delete-bucket', second_bucket_name])
+    b2_api.clean_bucket(second_bucket_name)
 
 
 def test_sse_b2(b2_tool, bucket_name):
@@ -1902,7 +1902,7 @@ def test_profile_switch(b2_tool):
         os.environ[B2_ACCOUNT_INFO_ENV_VAR] = B2_ACCOUNT_INFO
 
 
-def test_replication_basic(b2_tool, bucket_name):
+def test_replication_basic(b2_api, b2_tool, bucket_name):
     key_one_name = 'clt-testKey-01' + random_hex(6)
     created_key_stdout = b2_tool.should_succeed(
         [
@@ -2046,10 +2046,10 @@ def test_replication_basic(b2_tool, bucket_name):
 
     b2_tool.should_succeed(['delete-key', key_one_id])
     b2_tool.should_succeed(['delete-key', key_two_id])
-    b2_tool.should_succeed(['delete-bucket', source_bucket_name])
+    b2_api.clean_bucket(source_bucket_name)
 
 
-def test_replication_setup(b2_tool, bucket_name):
+def test_replication_setup(b2_api, b2_tool, bucket_name):
     source_bucket_name = b2_tool.generate_bucket_name()
     b2_tool.should_succeed(
         [
@@ -2102,7 +2102,7 @@ def test_replication_setup(b2_tool, bucket_name):
         'sourceToDestinationKeyMapping'].items():
         b2_tool.should_succeed(['delete-key', key_one_id])
         b2_tool.should_succeed(['delete-key', key_two_id])
-    b2_tool.should_succeed(['delete-bucket', source_bucket_name])
+    b2_api.clean_bucket(source_bucket_name)
     assert destination_bucket_old['replication']['asReplicationDestination'][
         'sourceToDestinationKeyMapping'] == destination_bucket['replication'][
             'asReplicationDestination']['sourceToDestinationKeyMapping']

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -16,6 +16,7 @@ import os
 import os.path
 import re
 
+from pathlib import Path
 from typing import Optional, Tuple
 
 from b2sdk.v2 import B2_ACCOUNT_INFO_ENV_VAR, SSE_C_KEY_ID_FILE_INFO_KEY_NAME, UNKNOWN_FILE_RETENTION_SETTING, EncryptionMode, EncryptionSetting, FileRetentionSetting, LegalHold, RetentionMode, fix_windows_path_limit
@@ -1007,7 +1008,7 @@ def test_sync_long_path(b2_tool, bucket_name):
 
     with TempDir() as dir_path:
         local_long_path = (dir_path / long_path).resolve()
-        fixed_local_long_path = fix_windows_path_limit(local_long_path)
+        fixed_local_long_path = Path(fix_windows_path_limit(str(local_long_path)))
         os.makedirs(fixed_local_long_path.parent)
         write_file(fixed_local_long_path, b'asdf')
 


### PR DESCRIPTION
This fixes following issues in integration tests:

### Revert --destination-profile being required

> E       AssertionError: FAILED with status 2, stderr=
> E       b2 replication-status: error: the following arguments are required: --destination-profile

This is triggered by change in e875e211d2dd2663512011d1413be63ac0edf788, reverted. Destination profile is optional for replication status.

### Fix replication test failure due to incorrect init order

> E       AssertionError: FAILED with status 1, stderr=ERROR: The source replication configuration is invalid. Ensure that the destinationBucketId is valid and that the source application key has the writeFiles capability for the destination bucket OR that the destination bucket has been configured with a mapping of the source application key to an application key. (bad_request)

This is triggered by internal B2 API change which now requires setting up destination before source.

### "Bucket does not exist" error

There is no safe way to clean up account before and after tests unless it's done via separate CI step. Doing this as a fixture will fall into race condition, as multiple test processes are run simultaneously with the same account.

### Too many buckets

Since all test processes (and even other repo: "sdk") share the same account, they theoretically could reach the limit of 100 buckets per account. This repo runs around 16 test processes, this creating at least 16 buckets at a time.

1. Xdist parallel count is decreased to 4
2. Buckets are now created before and deleted after each test, which should result in at most 2 buckets at a time per test (some tests create second bucket).
3. A CI step "cleanup_buckets" was created which cleans up old buckets before any tests.
4. Added retry for bucket cleanup function

### Better replication monitoring test

This includes changes from PR #111 related to replication status test, which include testing monitoring after uploading encrypted files. SSE-C-encrypted files made the test to fail, it's fixed on sdk level in [B2 sdk PR225](https://github.com/reef-technologies/b2-sdk-python/pull/225).