### PR TITLE
Update tests to use new source_encryption_mode field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Fix `replication-setup` default priority setter
+* Fix `replication-status` encryption mode display
 
 ## [3.5.0] - 2022-07-27
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 arrow>=1.0.2,<2.0.0
-b2sdk==1.17.3
+b2sdk==1.17.4
 docutils==0.19
 idna>=2.2.0; platform_system == 'Java'
 importlib-metadata>=3.3.0; python_version < '3.8'

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -2285,7 +2285,7 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
                         "source_has_hide_marker": None,
                         "source_has_large_metadata": None,
                         "source_has_legal_hold": None,
-                        "source_has_sse_c_enabled": None,
+                        "source_encryption_mode": None,
                         "source_replication_status": None,
                     }
                 ],
@@ -2300,7 +2300,7 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
                         "source_has_hide_marker": False,
                         "source_has_large_metadata": False,
                         "source_has_legal_hold": True,
-                        "source_has_sse_c_enabled": False,
+                        "source_encryption_mode": 'none',
                         "source_replication_status": first,
                     }, {
                         "count": 1,
@@ -2311,7 +2311,7 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
                         "source_has_hide_marker": False,
                         "source_has_large_metadata": False,
                         "source_has_legal_hold": False,
-                        "source_has_sse_c_enabled": False,
+                        "source_encryption_mode": 'SSE-B2',
                         "source_replication_status": second,
                     }, {
                         "count": 1,
@@ -2322,7 +2322,7 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
                         "source_has_hide_marker": False,
                         "source_has_large_metadata": False,
                         "source_has_legal_hold": False,
-                        "source_has_sse_c_enabled": True,
+                        "source_encryption_mode": 'SSE-C',
                         "source_replication_status": None,
                     }, {
                         "count": 1,
@@ -2333,7 +2333,7 @@ def test_replication_monitoring(b2_tool, bucket_name, b2_api):
                         "source_has_hide_marker": False,
                         "source_has_large_metadata": False,
                         "source_has_legal_hold": True,
-                        "source_has_sse_c_enabled": True,
+                        "source_encryption_mode": 'SSE-C',
                         "source_replication_status": None,
                     }
                 ]


### PR DESCRIPTION
This PR depends on https://github.com/reef-technologies/b2-sdk-python/pull/227.
Displaying the field does not need any changes, the b2 sdk change is picked up automatically.