### PR TITLE
Fix leaking buckets in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 env:
   PYTHON_DEFAULT_VERSION: "3.10"
 
+concurrency: continuous-integration
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix running tests on the CI with the latest SDK from the master branch
 * Fix bucket leaks in integration tests
 * Allow only one CI workflow at a time
+* Re-enable pytest-xdist for integration tests
 
 ## [3.5.0] - 2022-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix warnings in tests
 * Fix `test_keys` unit test after changes in b2sdk
 * Fix running tests on the CI with the latest SDK from the master branch
+* Fix bucket leaks in integration tests
 
 ## [3.5.0] - 2022-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix `test_keys` unit test after changes in b2sdk
 * Fix running tests on the CI with the latest SDK from the master branch
 * Fix bucket leaks in integration tests
+* Allow only one CI workflow at a time
 
 ## [3.5.0] - 2022-07-27
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -174,10 +174,9 @@ def integration(session):
     """Run integration tests."""
     install_myself(session)
     session.run('pip', 'install', *REQUIREMENTS_TEST)
-    #session.run('pytest', '-s', '-x', '-v', '-n', '4', *session.posargs, 'test/integration')
     session.run(
-        'pytest', '-s', '-x', '-v', '-W', 'ignore::DeprecationWarning:rst2ansi.visitor:',
-        *session.posargs, 'test/integration'
+        'pytest', '-s', '-x', '-v', '-n', 'auto', '-W',
+        'ignore::DeprecationWarning:rst2ansi.visitor:', *session.posargs, 'test/integration'
     )
 
 

--- a/test/integration/cleanup_buckets.py
+++ b/test/integration/cleanup_buckets.py
@@ -13,4 +13,4 @@ def test_cleanup_buckets(b2_api):
     # this is not a test, but it is intended to be called
     # via pytest because it reuses fixtures which have everything
     # set up
-    b2_api.clean_buckets()
+    b2_api.clean_all_buckets()


### PR DESCRIPTION
This PR fixes bucket clean ups during integration test teardown.  This is achieved by tracking created and deleted buckets (both via the API and the CLI) and deleting everything which might have not been deleted automatically after each test case.

Additionally, a `create_test_bucket` fixture factory has been introduced, which allows for easy bucket creation.  This is useful especially in tests, which need to create more than one bucket.  The `bucket_name` fixture is still available and in use in simpler test cases.

Some buckets are still created using the `create-bucket` CLI command -- this was left this way on purpose, to ensure the command and its switches are covered by tests too.

The PR also re-enables parallel integration test execution (`pytest-xdist`) as it should work correctly now.  It also introduces a change in the CI workflow config to only allow running one workflow at a time.

**This should be reviewed together with corresponding changes in the SDK: reef-technologies/b2-sdk-python#237.**

**Tests will fail unless #125 and Backblaze/B2_Command_Line_Tool#818 are merged.**  (These will fail on the master branch with the latest SDK version from master too).