### PR TITLE
Duplicated alias for commands are skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* Fix issues when running commands on Python 3.11
+
 ## [3.6.0] - 2022-09-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix warnings in tests
 * Fix `test_keys` unit test after changes in b2sdk
 * Fix running tests on the CI with the latest SDK from the master branch
+* Fix issues when running commands on Python 3.11
 
 ## [3.5.0] - 2022-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix warnings in tests
 * Fix `test_keys` unit test after changes in b2sdk
 * Fix running tests on the CI with the latest SDK from the master branch
-* Fix issues when running commands on Python 3.11
 
 ## [3.5.0] - 2022-07-27
 

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -524,13 +524,19 @@ class Command(Described):
             )
         else:
             name, alias = cls.name_and_alias()
-            parser = subparsers.add_parser(
-                name,
-                description=description,
-                parents=parents,
-                aliases=[alias] if alias is not None and not for_docs else (),
-                for_docs=for_docs,
-            )
+            try:
+                parser = subparsers.add_parser(
+                    name,
+                    description=description,
+                    parents=parents,
+                    aliases=[alias] if alias is not None and not for_docs else (),
+                    for_docs=for_docs,
+                )
+            except argparse.ArgumentError:
+                # In 3.11 a bug with duplicated subparsers was fixed https://github.com/python/cpython/issues/83897
+                # This leads to argument error, since all our parsers are registered for both name and alias.
+                # Whenever a name appears again an ArgumentError is raised, and we simply skip it.
+                return
 
         cls._setup_parser(parser)
 

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -524,19 +524,13 @@ class Command(Described):
             )
         else:
             name, alias = cls.name_and_alias()
-            try:
-                parser = subparsers.add_parser(
-                    name,
-                    description=description,
-                    parents=parents,
-                    aliases=[alias] if alias is not None and not for_docs else (),
-                    for_docs=for_docs,
-                )
-            except argparse.ArgumentError:
-                # In 3.11 a bug with duplicated subparsers was fixed https://github.com/python/cpython/issues/83897
-                # This leads to argument error, since all our parsers are registered for both name and alias.
-                # Whenever a name appears again an ArgumentError is raised, and we simply skip it.
-                return
+            parser = subparsers.add_parser(
+                name,
+                description=description,
+                parents=parents,
+                aliases=[alias] if alias is not None and not for_docs else (),
+                for_docs=for_docs,
+            )
 
         cls._setup_parser(parser)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,6 +8,7 @@
 #
 ######################################################################
 
+import io
 import os
 import pkg_resources
 import platform
@@ -23,13 +24,7 @@ INSTALL_SDK_FROM = os.environ.get('INSTALL_SDK_FROM')
 NO_STATICX = os.environ.get('NO_STATICX') is not None
 NOX_PYTHONS = os.environ.get('NOX_PYTHONS')
 
-PYTHON_VERSIONS = [
-    '3.7',
-    '3.8',
-    '3.9',
-    '3.10',
-    '3.11',
-] if NOX_PYTHONS is None else NOX_PYTHONS.split(',')
+PYTHON_VERSIONS = ['3.7', '3.8', '3.9', '3.10'] if NOX_PYTHONS is None else NOX_PYTHONS.split(',')
 PYTHON_DEFAULT_VERSION = PYTHON_VERSIONS[-1]
 
 PY_PATHS = ['b2', 'test', 'noxfile.py', 'setup.py']

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,6 @@
 #
 ######################################################################
 
-import io
 import os
 import pkg_resources
 import platform
@@ -24,7 +23,13 @@ INSTALL_SDK_FROM = os.environ.get('INSTALL_SDK_FROM')
 NO_STATICX = os.environ.get('NO_STATICX') is not None
 NOX_PYTHONS = os.environ.get('NOX_PYTHONS')
 
-PYTHON_VERSIONS = ['3.7', '3.8', '3.9', '3.10'] if NOX_PYTHONS is None else NOX_PYTHONS.split(',')
+PYTHON_VERSIONS = [
+    '3.7',
+    '3.8',
+    '3.9',
+    '3.10',
+    '3.11',
+] if NOX_PYTHONS is None else NOX_PYTHONS.split(',')
 PYTHON_DEFAULT_VERSION = PYTHON_VERSIONS[-1]
 
 PY_PATHS = ['b2', 'test', 'noxfile.py', 'setup.py']


### PR DESCRIPTION
In 3.11 a bug with duplicated names/aliases of subparsers was fixed in https://github.com/python/cpython/issues/83897. This leads to an argument error being raised whenever a duplicate is found. In previous python versions additional parsers were just overridden without a warning.