### PR TITLE
No-list-bucket-upgrade fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Stop using b2sdk.v1 in arg_parser.py
 * Fix issues when running commands on Python 3.11
+* RestrictedBucketMissing exception is now properly caught and handled
 
 ### Infrastructure
 * GitHub CI got checkout action updated to v3 and setup-python to v4


### PR DESCRIPTION
There used to be a check for empty bucket name with a non empty bucket id, but recent change in b2sdk ensured that an exception is raised in that case or a bucket is added to cache. This led to a change of behaviour in tests. This brings the original behaviour back.