### PR TITLE
install bash autocomplete under local/share on POSIX systems

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt
 include LICENSE
+include contrib/bash_completion/b2

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,21 @@ def read_requirements(extra=None):
         return f.read().splitlines()
 
 
+_IS_POSIX = platform.system() != 'Windows'
+
+
+def _get_data_files():
+    if _IS_POSIX:
+        return [
+            ('share/bash-completion/completions', ['contrib/bash_completion/b2']),
+        ]
+    else:
+        return []
+
+
+data_files = _get_data_files()
+
+
 setup(
     name='b2',
     description='Command Line Tool for Backblaze B2',
@@ -121,10 +136,7 @@ setup(
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:
     # http://docs.python.org/3.10/distutils/setupscript.html#installing-additional-files # noqa
-    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=[
-        #('my_data', ['data/data_file'])
-    ],
+    data_files=data_files,
 
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow


### PR DESCRIPTION
This should make b2 bash autocomplete be picked up automatically in case if it was installed (using `pip install`) under `root` or user (IF user $HOME/.local/bin is in PATH). At the same time it does not mess with system/user files if we are just installing b2 into some venv. So far tested only on Ubuntu-based Linux.

Open questions (checkbox if resolved):
* [ ] IF someone installed `b2` under venv then this does nothing for them, we could resolve this by having `b2 install-autocomplete` command - do we want such extra utitlity?
* [ ] confirm this is indeed working on Mac OS
* [ ] should we adjust autocomplete install readme? https://github.com/reef-technologies/B2_Command_Line_Tool/blob/master/doc/bash_completion.md
  * For: there should be one way to do things, and we are not even using the same path to install bash completion right now when doing it automagically on `pip install`
  * Against: old way will work for old and new b2 package version users
* [ ] do we want any test for this (one of reasons why this is problematic is that we use `pip install -e` under CI/nox)