### PR TITLE
Autocomplete integration test fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,9 +150,11 @@ jobs:
       - name: Generate hashes
         id: hashes
         run: nox -vs make_dist_digest
-      - name: Run integration tests
+      - name: Run integration tests (without secrets)
+        run: nox -vs integration -- -m "not require_secrets"
+      - name: Run integration tests (with secrets)
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
-        run: nox -vs integration -- --sut=${{ steps.bundle.outputs.sut_path }} --cleanup
+        run: nox -vs integration -- --sut=${{ steps.bundle.outputs.sut_path }} -m "require_secrets" --cleanup
       - name: Upload assets
         if: failure()
         uses: actions/upload-artifact@v2
@@ -187,9 +189,11 @@ jobs:
       - name: Generate hashes
         id: hashes
         run: nox -vs make_dist_digest
-      - name: Run integration tests
+      - name: Run integration tests (without secrets)
+        run: nox -vs integration -- -m "not require_secrets"
+      - name: Run integration tests (with secrets)
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
-        run: nox -vs integration -- --sut=${{ steps.bundle.outputs.sut_path }} --cleanup
+        run: nox -vs integration -- --sut=${{ steps.bundle.outputs.sut_path }} -m "require_secrets" --cleanup
       - name: Upload assets
         if: failure()
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,11 @@ jobs:
         run: python -m pip install --upgrade nox pip setuptools
       - name: Run unit tests
         run: nox -vs unit
-      - name: Run integration tests
+      - name: Run integration tests (without secrets)
+        run: nox -vs integration -- -m "not require_secrets"
+      - name: Run integration tests (with secrets)
         if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
-        run: nox -vs integration -- --cleanup
+        run: nox -vs integration -- -m "require_secrets" --cleanup
   test-docker:
     needs: cleanup_buckets
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,8 @@ jobs:
       - name: Run integration tests (without secrets)
         run: nox -vs integration -- -m "not require_secrets"
       - name: Run integration tests (with secrets)
-        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' }}
+        # Limit CI workload by running integration tests with secrets only on edge Python versions.
+        if: ${{ env.B2_TEST_APPLICATION_KEY != '' && env.B2_TEST_APPLICATION_KEY_ID != '' && contains(fromJSON('["3.7", "pypy-3.7", "3.11"]'), matrix.python-version) }}
         run: nox -vs integration -- -m "require_secrets" --cleanup
   test-docker:
     needs: cleanup_buckets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Infrastructure
+* Limit GitHub CI workload by running most integration tests only against edge versions of supported Python versions
+
 ## [3.8.0] - 2023-03-23
 
 ### Added
-* Add `install-autocomplete` command for installing shell autocompletion (currently only bash is supported)
+* Add `install-autocomplete` command for installing shell autocompletion (currently only `bash` is supported)
 
 ### Fixed
 * Hitting the download endpoint twice in some cases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.8.0] - 2023-03-23
 
 ### Added
-* Add `install-autocomplete` command for installing shell autocompletion
+* Add `install-autocomplete` command for installing shell autocompletion (currently only bash is supported)
 
 ### Fixed
 * Hitting the download endpoint twice in some cases

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -3327,7 +3327,7 @@ class InstallAutocomplete(Command):
         shell = args.shell or detect_shell()
         if shell not in SUPPORTED_SHELLS:
             self._print_stderr(
-                f'ERROR: unsupported shell: %s. Supported shells: {SUPPORTED_SHELLS}. Use --shell to specify a target shell manually.'
+                f'ERROR: unsupported shell: {shell}. Supported shells: {SUPPORTED_SHELLS}. Use --shell to specify a target shell manually.'
             )
             return 1
 

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -3335,7 +3335,10 @@ class InstallAutocomplete(Command):
             autocomplete_install(NAME, shell=shell)
         except AutocompleteInstallError as e:
             raise CommandError(str(e)) from e
-        self._print(f'Autocomplete installed for {shell}.')
+        self._print(f'Autocomplete successfully installed for {shell}.')
+        self._print(
+            f'Spawn a new shell instance to use it (log in again or just type `{shell}` in your current shell to start a new session inside of the existing session).'
+        )
         return 0
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,10 @@ max-line-length=100
 max-complexity=10
 doctests=1
 
+[tool:pytest]
+markers =
+    require_secrets: mark a test as requiring secrets such as API keys
+
 [coverage:run]
 branch=true
 

--- a/test/integration/helpers.py
+++ b/test/integration/helpers.py
@@ -487,10 +487,10 @@ def random_hex(length):
     return ''.join(random.choice('0123456789abcdef') for _ in range(length))
 
 
-def skip_on_windows(*args, **kwargs):
+def skip_on_windows(*args, reason='Not supported on Windows', **kwargs):
     return pytest.mark.skipif(
         platform.system() == 'Windows',
-        reason='Autocomplete is not supported on Windows',
+        reason=reason,
     )(*args, **kwargs)
 
 

--- a/test/integration/test_autocomplete.py
+++ b/test/integration/test_autocomplete.py
@@ -16,11 +16,6 @@ import pytest
 from test.integration.helpers import dont_run_on_all_python_versions, \
     skip_on_windows
 
-# Autocomplete tests are non-critical, so we don't run them on all python versions
-dont_run_on_all_python_versions(allow_module_level=True)
-# pexpect used for tests won't work on Windows
-skip_on_windows(allow_module_level=True)
-
 TIMEOUT = 10
 
 BASHRC_CONTENT = """\
@@ -72,11 +67,15 @@ def shell(env):
     shell.close()
 
 
+@dont_run_on_all_python_versions
+@skip_on_windows
 def test_autocomplete_b2_commands(autocomplete_installed, shell):
     shell.send('b2 \t\t')
     shell.expect_exact(["authorize-account", "download-file-by-id", "get-bucket"], timeout=TIMEOUT)
 
 
+@dont_run_on_all_python_versions
+@skip_on_windows
 def test_autocomplete_b2_only_matching_commands(autocomplete_installed, shell):
     shell.send('b2 download-\t\t')
 
@@ -87,6 +86,8 @@ def test_autocomplete_b2_only_matching_commands(autocomplete_installed, shell):
         shell.expect_exact("get-bucket", timeout=0.5)
 
 
+@dont_run_on_all_python_versions
+@skip_on_windows
 def test_autocomplete_b2_bucket_n_file_name(
     autocomplete_installed, shell, b2_tool, bucket_name, file_name
 ):

--- a/test/integration/test_autocomplete.py
+++ b/test/integration/test_autocomplete.py
@@ -13,8 +13,7 @@ import os
 import pexpect
 import pytest
 
-from test.integration.helpers import dont_run_on_all_python_versions, \
-    skip_on_windows
+from test.integration.helpers import skip_on_windows
 
 TIMEOUT = 10
 
@@ -67,14 +66,12 @@ def shell(env):
     shell.close()
 
 
-@dont_run_on_all_python_versions
 @skip_on_windows
 def test_autocomplete_b2_commands(autocomplete_installed, shell):
     shell.send('b2 \t\t')
     shell.expect_exact(["authorize-account", "download-file-by-id", "get-bucket"], timeout=TIMEOUT)
 
 
-@dont_run_on_all_python_versions
 @skip_on_windows
 def test_autocomplete_b2_only_matching_commands(autocomplete_installed, shell):
     shell.send('b2 download-\t\t')
@@ -86,7 +83,6 @@ def test_autocomplete_b2_only_matching_commands(autocomplete_installed, shell):
         shell.expect_exact("get-bucket", timeout=0.5)
 
 
-@dont_run_on_all_python_versions
 @skip_on_windows
 def test_autocomplete_b2_bucket_n_file_name(
     autocomplete_installed, shell, b2_tool, bucket_name, file_name

--- a/test/integration/test_autocomplete.py
+++ b/test/integration/test_autocomplete.py
@@ -48,6 +48,7 @@ def bashrc(homedir):
 @pytest.fixture(scope="module")
 def env(homedir, monkey_patch):
     monkey_patch.setenv('HOME', str(homedir))
+    monkey_patch.setenv('SHELL', "/bin/bash")  # fix for running under github actions
     yield os.environ
 
 

--- a/test/integration/test_autocomplete.py
+++ b/test/integration/test_autocomplete.py
@@ -9,10 +9,17 @@
 ######################################################################
 
 import os
-import platform
 
 import pexpect
 import pytest
+
+from test.integration.helpers import dont_run_on_all_python_versions, \
+    skip_on_windows
+
+# Autocomplete tests are non-critical, so we don't run them on all python versions
+dont_run_on_all_python_versions(allow_module_level=True)
+# pexpect used for tests won't work on Windows
+skip_on_windows(allow_module_level=True)
 
 TIMEOUT = 10
 
@@ -24,13 +31,6 @@ echo "Just testing if we don't replace existing script" > /dev/null
 # regardless what is in there already
 # <<< just a test section <<<
 """
-
-
-def skip_on_windows(f):
-    return pytest.mark.skipif(
-        platform.system() == 'Windows',
-        reason='Autocomplete is not supported on Windows',
-    )(f)
 
 
 @pytest.fixture(scope="session")
@@ -71,13 +71,11 @@ def shell(env):
     shell.close()
 
 
-@skip_on_windows
 def test_autocomplete_b2_commands(autocomplete_installed, shell):
     shell.send('b2 \t\t')
     shell.expect_exact(["authorize-account", "download-file-by-id", "get-bucket"], timeout=TIMEOUT)
 
 
-@skip_on_windows
 def test_autocomplete_b2_only_matching_commands(autocomplete_installed, shell):
     shell.send('b2 download-\t\t')
 
@@ -88,7 +86,6 @@ def test_autocomplete_b2_only_matching_commands(autocomplete_installed, shell):
         shell.expect_exact("get-bucket", timeout=0.5)
 
 
-@skip_on_windows
 def test_autocomplete_b2_bucket_n_file_name(
     autocomplete_installed, shell, b2_tool, bucket_name, file_name
 ):

--- a/test/integration/test_autocomplete.py
+++ b/test/integration/test_autocomplete.py
@@ -51,7 +51,7 @@ def env(homedir, monkey_patch):
 def autocomplete_installed(env, homedir, bashrc):
     shell = pexpect.spawn('bash -i -c "b2 install-autocomplete"', env=env)
     try:
-        shell.expect_exact('Autocomplete installed for bash', timeout=TIMEOUT)
+        shell.expect_exact('Autocomplete successfully installed for bash', timeout=TIMEOUT)
     finally:
         shell.close()
     shell.wait()


### PR DESCRIPTION
[After merge it appeared integration test broken when run under CI](https://github.com/reef-technologies/B2_Command_Line_Tool/actions/runs/4499091271/jobs/7916547648). This PR fixes that (tested here: https://github.com/mjurbanski-reef/B2_Command_Line_Tool/pull/1 ).

Requested changes:
* [x] fix autocomplete integration test 
* [x] autocomplete is tested only on first and last supported Python versions
* [x] integration tests using credentials should be run separately 

I will have to get discuss the last point. For now the changes present in this PR should at least unblock the release.