### PR TITLE
cd: build snap package

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -158,3 +158,11 @@ jobs:
           context: .
           push: true
           tags: backblaze/b2:${{ steps.build.outputs.version }}
+
+  snap-release:
+    if: ${{ vars.B2_DEBIAN_BUCKET_UPLOAD }}
+    name: Build Snap Package
+    uses: ./.github/workflows/cd_snap.yml
+    secrets: inherit
+    with:
+      b2-upload-bucket: ${{ vars.B2_DEBIAN_BUCKET_UPLOAD }}

--- a/.github/workflows/cd_snap.yml
+++ b/.github/workflows/cd_snap.yml
@@ -1,0 +1,28 @@
+name: Snap Package Continuous Delivery
+
+on:
+  workflow_call:
+    inputs:
+      b2-upload-bucket:
+        required: true
+        type: string
+
+jobs:
+  build-deb:
+    env:
+      B2_APPLICATION_KEY_ID: '${{ secrets.B2_DEBIAN_APPLICATION_KEY_ID }}'
+      B2_APPLICATION_KEY: '${{ secrets.B2_DEBIAN_APPLICATION_KEY }}'
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: snapcore/action-build@v1
+        id: snapcraft
+
+      - name: Upload to B2
+        run: |
+          pip install -U wheel b2
+          b2 upload_file ${{ inputs.b2-upload-bucket }} ${{ steps.snapcraft.outputs.snap }} ${{ steps.snapcraft.outputs.snap }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ venv
 doc/source/main_help.rst
 Dockerfile
 b2/licenses_output.txt
+# snap package
+parts
+prime
+stage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 requires-python = ">=3.7"
 name = "b2"
-version = "0.0.0"  # this is wrong, but setuptools>61 insists its here
+dynamic = ["version"]
 
 [tool.ruff]
 # TODO add D
@@ -17,3 +17,11 @@ line-length = 100
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "test/**" = ["D", "F403", "F405"]
+
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+version_scheme = "post-release"
+

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         'doc': read_requirements('doc'),
         'license': read_requirements('license'),
     },
-    setup_requires=['setuptools_scm<6.0'],
+    setup_requires=['setuptools_scm'],
     use_scm_version=True,
 
     # If there are data files included in your packages that need to be

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: backblaze-b2
+base: core22
+version: git
+summary: This program provides command-line access to the B2 service.
+description: The command-line tool that gives easy access to all of the capabilities of B2 Cloud Storage.
+adopt-info: backblaze-b2
+
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: arm64
+  - build-on: amd64
+
+apps:
+  backblaze-b2:
+    command: bin/b2
+    aliases: [ backblaze-b2 ]
+    plugs: [ network ]
+    environment:
+      PYTHONPATH: $PYTHONPATH:$SNAP/lib/python3.11/site-packages
+
+parts:
+  backblaze-b2:
+    source: .
+    source-type: git
+    plugin: python
+    build-packages:
+      - python3-setuptools
+      - python3-setuptools-scm
+
+    override-pull: |
+      snapcraftctl pull
+      # remove pyproject.toml until _fully_ migrated to it
+      mv pyproject.toml pyproject.toml_snapignore || true
+      version="$(python3 setup.py --version)"
+      craftctl set version=$version


### PR DESCRIPTION
Building `.snap` package

a few notes for if (when) someone will be digging into this:

- Snapcraft (tool for build snap packages) currently does not work on Apple Silicon due to a bug

- Snapcraft uses `lxd` for building packages, which currently contains a bug preventing network connections when running in Qemu (ie. UTM). 
    - there is another build system (multipass) but it also uses lxd, so using that instead does not change anything

- the build can be performed directly on the machine instead of in another layer of virtualization with the following env. variable `﻿﻿﻿SNAPCRAFT_BUILD_ENVIRONMENT=host`
    - Snapcraft however tries to run `apt-get update` for some reason, which does not work under normal user, so the most straightforward way how to avoid this error is to run the build under root (or use sticky bit maybe? idk, it's running in VM anyway).

- Snapcraft tries to determine version via `git describe` which looks up only "annotated tags" (which we dont do apparently), so there's added a fallback to determine the version via `setuptools_scm` (`python setup.py --version`)

- current `pyproject.toml` is not fully functional, so I'm moving it out of the way to avoid Snapcraft trying to use it instead of `setup.py`

- despite of that there are some changes in `pyproject.toml` which we'll eventually need when migrating to it. These changes are analogy of the following part in `setup.py`:
    
```
setup_requires=['setuptools_scm'],
use_scm_version=True,
```

- there is a bug (feature?) in Snapcraft which does not add `site-packages` inside the `.snap`, so it has to be manually appended into `PYTHONPATH` in the build file

- there is another bug in Snapcraft which doesnt install `b2.egg-info` and/or `b2.dist-info` into the `.snap`. I'm not sure about the precise circumstances, but it was happening when I defined `stage-packages` in the `snapcraft.yaml`. The snap package is created and can be installed, but when run it ends up with exception (`PackageNotFoundError: No package metadata was found for b2`). Didnt dig into it too deep, as the current configuration works.