### PR TITLE
Pypy dependency license resolution fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Fast rm sometimes failing due to a rare race condition
 * Fix UnicodeEncodeError in non-Unicode terminals by prioritizing stdout encoding
+* When listing licenses in `license` command only show licenses of `b2` and its dependencies
 
 ## [3.9.0] - 2023-04-28
 

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -28,6 +28,7 @@ import platform
 import queue
 import re
 import signal
+import subprocess
 import sys
 import threading
 import time
@@ -3267,6 +3268,15 @@ class License(Command):  # pragma: no cover
     @classmethod
     def _get_licenses_dicts(cls) -> List[Dict]:
         assert piplicenses, 'In order to run this command, you need to install the `license` extra: pip install b2[license]'
+        pipdeptree_run = subprocess.run(
+            ["pipdeptree", "--json", "-p", "b2"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        pipdeptree = json.loads(pipdeptree_run.stdout)
+        used_packages = [dep["package"]['package_name'] for dep in pipdeptree]
+
         parser = piplicenses.create_parser()
         args = parser.parse_args(
             [
@@ -3276,6 +3286,8 @@ class License(Command):  # pragma: no cover
                 '--with-authors',
                 '--with-urls',
                 '--with-license-file',
+                '--packages',
+                *used_packages,
             ]
         )
         licenses_output = piplicenses.create_output_string(args)

--- a/requirements-license.txt
+++ b/requirements-license.txt
@@ -1,2 +1,4 @@
 pip-licenses==3.5.5; python_version < '3.8'
 pip-licenses==4.3.2; python_version >= '3.8'
+pipdeptree~=2.9
+prettytable~=3.7


### PR DESCRIPTION
`setup-python` pypy310 seems to have installed all kinds of packages out of the box, and it didnt quite make sense to add all licenses of them into our b2 license list