### PR TITLE
integrated command line tool and updated the tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Declare official support of Python 3.12
+* Cache-Control option when uploading files
 
 ### Infrastructure
 * Remove unsupported PyPy 3.7 from tests matrix and add PyPy 3.10 instead

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -2654,6 +2654,7 @@ class UploadFile(
         parser.add_argument('--minPartSize', type=int)
         parser.add_argument('--sha1')
         parser.add_argument('--threads', type=int, default=10)
+        parser.add_argument('--cache-control', default=None)
         parser.add_argument('--info', action='append', default=[])
         parser.add_argument('--custom-upload-timestamp', type=int)
         parser.add_argument('bucketName').completer = bucket_name_completer
@@ -2691,6 +2692,7 @@ class UploadFile(
             legal_hold=legal_hold,
             upload_mode=self._get_upload_mode_from_args(args),
             custom_upload_timestamp=args.custom_upload_timestamp,
+            cache_control=args.cache_control,
         )
         if not args.quiet:
             self._print("URL by file name: " + bucket.get_download_url(args.b2FileName))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete>=2,<4
 arrow>=1.0.2,<2.0.0
-b2sdk>=1.22.2,<2
+b2sdk>=1.22.1,<2
 docutils==0.19
 idna~=2.2.0; platform_system == 'Java'
 importlib-metadata~=3.3; python_version < '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete>=2,<4
 arrow>=1.0.2,<2.0.0
-b2sdk~=1.21
+b2sdk @ git+https://github.com/fmessina-reef/b2-sdk-python.git#egg=b2sdk
 docutils==0.19
 idna~=2.2.0; platform_system == 'Java'
 importlib-metadata~=3.3; python_version < '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete>=2,<4
 arrow>=1.0.2,<2.0.0
-b2sdk @ git+https://github.com/fmessina-reef/b2-sdk-python.git#egg=b2sdk
+b2sdk>=1.22.2,<2
 docutils==0.19
 idna~=2.2.0; platform_system == 'Java'
 importlib-metadata~=3.3; python_version < '3.8'

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -793,10 +793,11 @@ class TestConsoleTool(BaseConsoleToolTest):
                 "contentSha1": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
                 "contentType": "b2/x-auto",
                 "fileId": "9999",
-                "fileInfo": {
-                    "src_last_modified_millis": "1500111222000",
-                    "b2-cache-control": "private, max-age=3600"
-                },
+                "fileInfo":
+                    {
+                        "src_last_modified_millis": "1500111222000",
+                        "b2-cache-control": "private, max-age=3600"
+                    },
                 "fileName": "file1.txt",
                 "serverSideEncryption": {
                     "mode": "none"
@@ -806,7 +807,10 @@ class TestConsoleTool(BaseConsoleToolTest):
             }
 
             self._run_command(
-                ['upload-file', '--noProgress', 'my-bucket', local_file1, 'file1.txt', '--cache-control=private, max-age=3600'],
+                [
+                    'upload-file', '--noProgress', 'my-bucket', local_file1, 'file1.txt',
+                    '--cache-control=private, max-age=3600'
+                ],
                 expected_json_in_stdout=expected_json,
                 remove_version=True,
                 expected_part_of_stdout=expected_stdout,
@@ -822,10 +826,11 @@ class TestConsoleTool(BaseConsoleToolTest):
                 "contentSha1": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
                 "contentType": "b2/x-auto",
                 "fileId": "9999",
-                "fileInfo": {
-                    "src_last_modified_millis": "1500111222000",
-                    "b2-cache-control": "private, max-age=3600"
-                },
+                "fileInfo":
+                    {
+                        "src_last_modified_millis": "1500111222000",
+                        "b2-cache-control": "private, max-age=3600"
+                    },
                 "fileName": "file1.txt",
                 "serverSideEncryption": {
                     "mode": "none"
@@ -908,10 +913,11 @@ class TestConsoleTool(BaseConsoleToolTest):
                     "contentSha1": "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
                     "contentType": "b2/x-auto",
                     "fileId": "9999",
-                    "fileInfo": {
-                        "src_last_modified_millis": str(mod_time_str),
-                        "b2-cache-control": "private, max-age=3600"
-                    },
+                    "fileInfo":
+                        {
+                            "src_last_modified_millis": str(mod_time_str),
+                            "b2-cache-control": "private, max-age=3600"
+                        },
                     "fileName": "file1.txt",
                     "serverSideEncryption": {
                         "mode": "none"

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -794,7 +794,8 @@ class TestConsoleTool(BaseConsoleToolTest):
                 "contentType": "b2/x-auto",
                 "fileId": "9999",
                 "fileInfo": {
-                    "src_last_modified_millis": "1500111222000"
+                    "src_last_modified_millis": "1500111222000",
+                    "b2-cache-control": "private, max-age=3600"
                 },
                 "fileName": "file1.txt",
                 "serverSideEncryption": {
@@ -805,7 +806,7 @@ class TestConsoleTool(BaseConsoleToolTest):
             }
 
             self._run_command(
-                ['upload-file', '--noProgress', 'my-bucket', local_file1, 'file1.txt'],
+                ['upload-file', '--noProgress', 'my-bucket', local_file1, 'file1.txt', '--cache-control=private, max-age=3600'],
                 expected_json_in_stdout=expected_json,
                 remove_version=True,
                 expected_part_of_stdout=expected_stdout,
@@ -822,7 +823,8 @@ class TestConsoleTool(BaseConsoleToolTest):
                 "contentType": "b2/x-auto",
                 "fileId": "9999",
                 "fileInfo": {
-                    "src_last_modified_millis": "1500111222000"
+                    "src_last_modified_millis": "1500111222000",
+                    "b2-cache-control": "private, max-age=3600"
                 },
                 "fileName": "file1.txt",
                 "serverSideEncryption": {
@@ -907,7 +909,8 @@ class TestConsoleTool(BaseConsoleToolTest):
                     "contentType": "b2/x-auto",
                     "fileId": "9999",
                     "fileInfo": {
-                        "src_last_modified_millis": str(mod_time_str)
+                        "src_last_modified_millis": str(mod_time_str),
+                        "b2-cache-control": "private, max-age=3600"
                     },
                     "fileName": "file1.txt",
                     "serverSideEncryption": {


### PR DESCRIPTION
CLI support to cache-control headers.

Please note, this can't be merged as long as this requirement has been fixed:
b2sdk @ git+https://github.com/fmessina-reef/b2-sdk-python.git#egg=b2sdk
Tests on pipeline are failing for a similar reason.