### PR TITLE
`ls` shell-like wildcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * When listing licenses in `license` command only show licenses of `b2` and its dependencies
 
 ### Changes
-* `ls` command now acts as if `--withWildcard` and when any folder name is supplied
-* Wildcard support for the `ls` and `rm` commands is now shell-like instead of glob-like
+* Wildcard style of the `ls` commands is now shell-like instead of glob-like
 
 ### Removed
-* Remove `--recursive` from `ls` command
-* Remove `--withWildcard` from `ls` command
+* Remove parameter `--recursive` from `ls` command
 
 ## [3.9.0] - 2023-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix UnicodeEncodeError in non-Unicode terminals by prioritizing stdout encoding
 * When listing licenses in `license` command only show licenses of `b2` and its dependencies
 
+## Changes
+* Wildcard support for the `ls` and `rm` commands is now shell-like instead of glob-like
+* `ls` command now acts as if `--withWildcard` was always set
+
+### Removed
+* Remove `--recursive` from `ls` command
+* Remove `--withWildcard` from `ls` command
+
 ## [3.9.0] - 2023-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * When listing licenses in `license` command only show licenses of `b2` and its dependencies
 
 ### Changes
-* `ls` command now acts as if `--withWildcard` was always set
+* `ls` command now acts as if `--withWildcard` and when any folder name is supplied
 * Wildcard support for the `ls` and `rm` commands is now shell-like instead of glob-like
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix UnicodeEncodeError in non-Unicode terminals by prioritizing stdout encoding
 * When listing licenses in `license` command only show licenses of `b2` and its dependencies
 
-## Changes
-* Wildcard support for the `ls` and `rm` commands is now shell-like instead of glob-like
+### Changes
 * `ls` command now acts as if `--withWildcard` was always set
+* Wildcard support for the `ls` and `rm` commands is now shell-like instead of glob-like
 
 ### Removed
 * Remove `--recursive` from `ls` command

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ b2 list-buckets [-h] [--json]
 b2 list-keys [-h] [--long]
 b2 list-parts [-h] largeFileId
 b2 list-unfinished-large-files [-h] bucketName
-b2 ls [-h] [--long] [--json] [--replication] [--versions] [--recursive] [--withWildcard] bucketName [folderName]
+b2 ls [-h] [--long] [--json] [--replication] [--versions] bucketName [folderName]
 b2 rm [-h] [--dryRun] [--threads THREADS] [--queueSize QUEUESIZE] [--noProgress] [--failFast] [--versions] [--recursive] [--withWildcard] bucketName [folderName]
 b2 make-url [-h] fileId
 b2 make-friendly-url [-h] bucketName fileName

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ b2 list-buckets [-h] [--json]
 b2 list-keys [-h] [--long]
 b2 list-parts [-h] largeFileId
 b2 list-unfinished-large-files [-h] bucketName
-b2 ls [-h] [--long] [--json] [--replication] [--versions] bucketName [folderName]
+b2 ls [-h] [--long] [--json] [--replication] [--versions] [--withWildcard] bucketName [folderName]
 b2 rm [-h] [--dryRun] [--threads THREADS] [--queueSize QUEUESIZE] [--noProgress] [--failFast] [--versions] [--recursive] [--withWildcard] bucketName [folderName]
 b2 make-url [-h] fileId
 b2 make-friendly-url [-h] bucketName fileName

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1753,9 +1753,10 @@ class AbstractLsCommand(Command, metaclass=ABCMeta):
         try:
             file_version, folder_name = next(generator)
         except StopIteration:
-            # folder not found, exit with error
-            print(f"No such file or directory: {args.folderName}", file=sys.stderr)
-            return 1
+            if args.folderName is not None:
+                # specific path requested but not found, exit with error
+                print(f"No such file or directory: {args.folderName}", file=sys.stderr)
+                return 1
         else:
             self._print_file_version(args, file_version, folder_name)
 
@@ -1783,7 +1784,7 @@ class AbstractLsCommand(Command, metaclass=ABCMeta):
                 latest_only=not args.versions,
                 recursive=args.recursive,
                 with_wildcard=args.withWildcard,
-                #wildcard_style='shell',
+                wildcard_style='shell',
             )
         except ValueError as error:
             # Wrap these errors into B2Error. At the time of writing there's
@@ -2066,8 +2067,8 @@ class Rm(AbstractLsCommand):
 
             self.reporter.end_total()
 
-            if not self.reporter.total_count:
-                # folder doesn't exist, exit with error
+            if not self.reporter.total_count and self.args.folderName is not None:
+                # specific path requested but not found, exit with error
                 self.messages_queue.put(
                     (self.ERROR_TAG, None, f"No such file or directory: `{self.args.folderName}`")
                 )

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1740,6 +1740,7 @@ class AbstractLsCommand(Command, metaclass=ABCMeta):
 
     Remember to quote ``folderName`` to avoid shell expansion.
     """
+    wildcard_style = 'shell'  # TODO B2-13 remove with rm changes implementation
 
     @classmethod
     def _setup_parser(cls, parser):
@@ -1785,7 +1786,7 @@ class AbstractLsCommand(Command, metaclass=ABCMeta):
                 latest_only=not args.versions,
                 recursive=args.recursive,
                 with_wildcard=args.withWildcard,
-                wildcard_style='shell',
+                wildcard_style=self.wildcard_style,
             )
         except ValueError as error:
             # Wrap these errors into B2Error. At the time of writing there's
@@ -1811,6 +1812,10 @@ class Ls(AbstractLsCommand):
     the server api response format.
 
     The ``--replication`` option adds replication status
+
+    The ``--withWildcard`` option will allow using ``*``, ```**```, ``?``, ``[]``, ``{{}}``
+    characters in ``folderName`` as a non-greedy wildcard, greedy-wildcard, single character
+    wildcard, range of characters, and sequence of characters respectively.
 
     {ABSTRACTLSCOMMAND}
 
@@ -2013,6 +2018,7 @@ class Rm(AbstractLsCommand):
 
     DEFAULT_THREADS = 10
     PROGRESS_REPORT_CLASS = ProgressReport
+    wildcard_style = 'glob'  # TODO B2-13 remove with rm changes implementation
 
     class SubmitThread(threading.Thread):
         END_MARKER = object()

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1821,21 +1821,26 @@ class Ls(AbstractLsCommand):
         characters are not expanded by the shell.
 
 
-    List csv and tsv files (in any directory, in the whole bucket):
+    List csv and tsv files (in the current directory):
 
     .. code-block::
 
         {NAME} ls bucketName "*.[ct]sv"
 
+    List csv and tsv files (in any directory, in the whole bucket):
 
-    List all info.txt files from buckets bX, where X is any character:
+    .. code-block::
+
+        {NAME} ls bucketName "**/*.[ct]sv"
+
+    List all info.txt files from directories bX, where X is any character:
 
     .. code-block::
 
         {NAME} ls bucketName "b?/info.txt"
 
 
-    List all pdf files from buckets b0 to b9 (including sub-directories):
+    List all pdf files from directories b0 to b9 (including sub-directories):
 
     .. code-block::
 
@@ -1936,8 +1941,8 @@ class Rm(AbstractLsCommand):
     The ``--recursive`` option will descend into folders, deleting all files
 
     The ``--withWildcard`` option will allow using ``*``, ```**```, ``?``, ``[]``, ``{{}}``
-    characters in ``folderName`` as a greedy wildcard, single character
-    wildcard and range of characters. It requires the ``--recursive`` option.
+    characters in ``folderName`` as a non-greedy wildcard, greedy-wildcard, single character
+    wildcard, range of characters, and sequence of characters respectively. It requires the ``--recursive`` option.
 
     {ABSTRACTLSCOMMAND}
 
@@ -2065,7 +2070,7 @@ class Rm(AbstractLsCommand):
             if not self.reporter.total_count:
                 # folder doesn't exist, exit with error
                 self.messages_queue.put(
-                    (self.ERROR_TAG, None, f"Folder not found: `{self.args.folderName}`")
+                    (self.ERROR_TAG, None, f"No such file or directory: `{self.args.folderName}`")
                 )
 
         def _removal_done(self, future: Future) -> None:

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1744,6 +1744,7 @@ class AbstractLsCommand(Command, metaclass=ABCMeta):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('--versions', action='store_true')
+        parser.add_argument('--withWildcard', action='store_true')
         parser.add_argument('bucketName').completer = bucket_name_completer
         parser.add_argument('folderName', nargs='?').completer = file_name_completer
 
@@ -1865,7 +1866,7 @@ class Ls(AbstractLsCommand):
 
     def run(self, args):
         # if not folder is specified, list root folder only
-        args.recursive = args.withWildcard = args.folderName is not None
+        args.recursive = args.folderName is not None
         if args.json:
             # TODO: Make this work for an infinite generation.
             #   Use `_print_file_version` to print a single `file_version` and manage the external JSON list
@@ -2098,7 +2099,6 @@ class Rm(AbstractLsCommand):
     @classmethod
     def _setup_parser(cls, parser):
         parser.add_argument('-r', '--recursive', action='store_true')
-        parser.add_argument('--withWildcard', action='store_true')
         parser.add_argument('--dryRun', action='store_true')
         parser.add_argument('--threads', type=int, default=cls.DEFAULT_THREADS)
         parser.add_argument(

--- a/b2/console_tool.py
+++ b/b2/console_tool.py
@@ -1777,14 +1777,13 @@ class AbstractLsCommand(Command, metaclass=ABCMeta):
         start_file_name = args.folderName or ''
 
         bucket = self.api.get_bucket_by_name(args.bucketName)
-
         try:
             yield from bucket.ls(
                 start_file_name,
                 latest_only=not args.versions,
                 recursive=args.recursive,
                 with_wildcard=args.withWildcard,
-                wildcard_style='shell',
+                #wildcard_style='shell',
             )
         except ValueError as error:
             # Wrap these errors into B2Error. At the time of writing there's
@@ -1864,8 +1863,8 @@ class Ls(AbstractLsCommand):
         super()._setup_parser(parser)
 
     def run(self, args):
-        args.recursive = True
-        args.withWildcard = True
+        # if not folder is specified, list root folder only
+        args.recursive = args.withWildcard = args.folderName is not None
         if args.json:
             # TODO: Make this work for an infinite generation.
             #   Use `_print_file_version` to print a single `file_version` and manage the external JSON list

--- a/test/integration/helpers.py
+++ b/test/integration/helpers.py
@@ -444,8 +444,7 @@ class CommandLine:
             assert re.search(expected_pattern, stdout), \
             f'did not match pattern="{expected_pattern}", stdout="{stdout}"'
 
-        stdout = [x for x in stdout.split('\n') if not x.startswith('XXX')]
-        return "\n".join(stdout)
+        return "\n".join([x for x in stdout.split('\n') if not x.strip().startswith('DEBUG:')])
 
     def should_succeed_json(self, args, additional_env: Optional[dict] = None):
         """
@@ -483,7 +482,10 @@ class CommandLine:
             assert not missing_capabilities, f'it appears that the raw_api integration test is being run with a non-full key. Missing capabilities: {missing_capabilities}'
 
     def list_file_versions(self, bucket_name):
-        return self.should_succeed_json(['ls', '--json', '--versions', bucket_name, '**'])
+        # TODO B2-13 replace with `find` command
+        return self.should_succeed_json(
+            ['ls', '--json', '--withWildcard', '--versions', bucket_name, '**']
+        )
 
 
 class TempDir:

--- a/test/integration/helpers.py
+++ b/test/integration/helpers.py
@@ -218,7 +218,7 @@ class Api:
                 self.api.update_file_legal_hold(
                     file_version_info.id_, file_version_info.file_name, LegalHold.OFF
                 )
-            print('Removing file version:', file_version_info.id_)
+            print('Removing file version:', file_version_info.id_, file_version_info.file_name)
             try:
                 self.api.delete_file_version(file_version_info.id_, file_version_info.file_name)
             except FileNotPresent:
@@ -444,7 +444,8 @@ class CommandLine:
             assert re.search(expected_pattern, stdout), \
             f'did not match pattern="{expected_pattern}", stdout="{stdout}"'
 
-        return stdout
+        stdout = [x for x in stdout.split('\n') if not x.startswith('XXX')]
+        return "\n".join(stdout)
 
     def should_succeed_json(self, args, additional_env: Optional[dict] = None):
         """
@@ -482,7 +483,7 @@ class CommandLine:
             assert not missing_capabilities, f'it appears that the raw_api integration test is being run with a non-full key. Missing capabilities: {missing_capabilities}'
 
     def list_file_versions(self, bucket_name):
-        return self.should_succeed_json(['ls', '--json', '--recursive', '--versions', bucket_name])
+        return self.should_succeed_json(['ls', '--json', '--versions', bucket_name, '**'])
 
 
 class TempDir:

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -118,7 +118,9 @@ def test_basic(b2_tool, bucket_name):
     b2_tool.should_succeed(['upload-file', '--noProgress', bucket_name, file_to_upload, 'rm1'])
     # with_wildcard allows us to target a single file. rm will be removed, rm1 will be left alone
     b2_tool.should_succeed(['rm', '--recursive', '--withWildcard', bucket_name, 'rm'])
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name, 'rm*'])
+    list_of_files = b2_tool.should_succeed_json(
+        ['ls', '--withWildcard', '--json', bucket_name, 'rm*']
+    )
     should_equal(['rm1'], [f['fileName'] for f in list_of_files])
     b2_tool.should_succeed(['rm', '--recursive', '--withWildcard', bucket_name, 'rm1'])
 
@@ -129,11 +131,15 @@ def test_basic(b2_tool, bucket_name):
 
     b2_tool.should_succeed(['hide-file', bucket_name, 'c'])
 
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name, '**'])
+    # TODO B2-13 replace with `find` command
+    list_of_files = b2_tool.should_succeed_json(
+        ['ls', '--json', '--withWildcard', bucket_name, '**']
+    )
     should_equal(['a', 'b/1', 'b/2', 'd'], [f['fileName'] for f in list_of_files])
 
+    # TODO B2-13 replace with `find` command
     list_of_files = b2_tool.should_succeed_json(
-        ['ls', '--json', '--versions', bucket_name, '**']
+        ['ls', '--json', '--withWildcard', '--versions', bucket_name, '**']
     )
     should_equal(['a', 'a', 'b/1', 'b/2', 'c', 'c', 'd'], [f['fileName'] for f in list_of_files])
     should_equal(
@@ -145,9 +151,7 @@ def test_basic(b2_tool, bucket_name):
 
     first_c_version = list_of_files[4]
     second_c_version = list_of_files[5]
-    list_of_files = b2_tool.should_succeed_json(
-        ['ls', '--json', '--versions', bucket_name, 'c']
-    )
+    list_of_files = b2_tool.should_succeed_json(['ls', '--json', '--versions', bucket_name, 'c'])
     should_equal([], [f['fileName'] for f in list_of_files])
 
     b2_tool.should_succeed(['copy-file-by-id', first_a_version['fileId'], bucket_name, 'x'])
@@ -1141,7 +1145,10 @@ def test_sse_b2(b2_tool, bucket_name):
             ]
         )
 
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name, '**'])
+    # TODO B2-13 replace with `find` command
+    list_of_files = b2_tool.should_succeed_json(
+        ['ls', '--json', '--withWildcard', bucket_name, '**']
+    )
     should_equal(
         [{
             'algorithm': 'AES256',
@@ -1168,7 +1175,10 @@ def test_sse_b2(b2_tool, bucket_name):
         ['copy-file-by-id', not_encrypted_version['fileId'], bucket_name, 'copied_not_encrypted']
     )
 
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name, '**'])
+    # TODO B2-13 replace with `find` command
+    list_of_files = b2_tool.should_succeed_json(
+        ['ls', '--json', '--withWildcard', bucket_name, '**']
+    )
     should_equal(
         [{
             'algorithm': 'AES256',
@@ -1396,7 +1406,7 @@ def test_sse_c(b2_tool, bucket_name):
             'B2_DESTINATION_SSE_C_KEY_ID': 'another-user-generated-key-id',
         }
     )
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json',  bucket_name])
+    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name])
     should_equal(
         [
             {

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -129,11 +129,11 @@ def test_basic(b2_tool, bucket_name):
 
     b2_tool.should_succeed(['hide-file', bucket_name, 'c'])
 
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name])
+    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name, '**'])
     should_equal(['a', 'b/1', 'b/2', 'd'], [f['fileName'] for f in list_of_files])
 
     list_of_files = b2_tool.should_succeed_json(
-        ['ls', '--json', '--versions', bucket_name]
+        ['ls', '--json', '--versions', bucket_name, '**']
     )
     should_equal(['a', 'a', 'b/1', 'b/2', 'c', 'c', 'd'], [f['fileName'] for f in list_of_files])
     should_equal(
@@ -1141,7 +1141,7 @@ def test_sse_b2(b2_tool, bucket_name):
             ]
         )
 
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name])
+    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name, '**'])
     should_equal(
         [{
             'algorithm': 'AES256',
@@ -1168,7 +1168,7 @@ def test_sse_b2(b2_tool, bucket_name):
         ['copy-file-by-id', not_encrypted_version['fileId'], bucket_name, 'copied_not_encrypted']
     )
 
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name])
+    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name, '**'])
     should_equal(
         [{
             'algorithm': 'AES256',

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -118,9 +118,7 @@ def test_basic(b2_tool, bucket_name):
     b2_tool.should_succeed(['upload-file', '--noProgress', bucket_name, file_to_upload, 'rm1'])
     # with_wildcard allows us to target a single file. rm will be removed, rm1 will be left alone
     b2_tool.should_succeed(['rm', '--recursive', '--withWildcard', bucket_name, 'rm'])
-    list_of_files = b2_tool.should_succeed_json(
-        ['ls', '--json', '--recursive', '--withWildcard', bucket_name, 'rm*']
-    )
+    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name, 'rm*'])
     should_equal(['rm1'], [f['fileName'] for f in list_of_files])
     b2_tool.should_succeed(['rm', '--recursive', '--withWildcard', bucket_name, 'rm1'])
 

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -129,11 +129,11 @@ def test_basic(b2_tool, bucket_name):
 
     b2_tool.should_succeed(['hide-file', bucket_name, 'c'])
 
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json', '--recursive', bucket_name])
+    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name])
     should_equal(['a', 'b/1', 'b/2', 'd'], [f['fileName'] for f in list_of_files])
 
     list_of_files = b2_tool.should_succeed_json(
-        ['ls', '--json', '--recursive', '--versions', bucket_name]
+        ['ls', '--json', '--versions', bucket_name]
     )
     should_equal(['a', 'a', 'b/1', 'b/2', 'c', 'c', 'd'], [f['fileName'] for f in list_of_files])
     should_equal(
@@ -146,7 +146,7 @@ def test_basic(b2_tool, bucket_name):
     first_c_version = list_of_files[4]
     second_c_version = list_of_files[5]
     list_of_files = b2_tool.should_succeed_json(
-        ['ls', '--json', '--recursive', '--versions', bucket_name, 'c']
+        ['ls', '--json', '--versions', bucket_name, 'c']
     )
     should_equal([], [f['fileName'] for f in list_of_files])
 
@@ -1141,7 +1141,7 @@ def test_sse_b2(b2_tool, bucket_name):
             ]
         )
 
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json', '--recursive', bucket_name])
+    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name])
     should_equal(
         [{
             'algorithm': 'AES256',
@@ -1168,7 +1168,7 @@ def test_sse_b2(b2_tool, bucket_name):
         ['copy-file-by-id', not_encrypted_version['fileId'], bucket_name, 'copied_not_encrypted']
     )
 
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json', '--recursive', bucket_name])
+    list_of_files = b2_tool.should_succeed_json(['ls', '--json', bucket_name])
     should_equal(
         [{
             'algorithm': 'AES256',
@@ -1396,7 +1396,7 @@ def test_sse_c(b2_tool, bucket_name):
             'B2_DESTINATION_SSE_C_KEY_ID': 'another-user-generated-key-id',
         }
     )
-    list_of_files = b2_tool.should_succeed_json(['ls', '--json', '--recursive', bucket_name])
+    list_of_files = b2_tool.should_succeed_json(['ls', '--json',  bucket_name])
     should_equal(
         [
             {

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -2116,7 +2116,8 @@ class TestConsoleTool(BaseConsoleToolTest):
         b/b2
         c
         '''
-        self._run_command(['ls', 'my-bucket', '**'], expected_stdout, '', 0)
+        # TODO B2-13 replace with `find` command
+        self._run_command(['ls', '--withWildcard', 'my-bucket', '**'], expected_stdout, '', 0)
 
         # Check long output.   (The format expects full-length file ids, so it causes whitespace here)
         expected_stdout = '''
@@ -2133,14 +2134,14 @@ class TestConsoleTool(BaseConsoleToolTest):
                                                                                        9995  upload  1970-01-01  00:00:05          6  c
                                                                                        9996  upload  1970-01-01  00:00:05          5  c
         '''
-        self._run_command(['ls', '-l', '--versions', 'my-bucket'], expected_stdout, '', 0)
+        self._run_command(['ls', '--long', '--versions', 'my-bucket'], expected_stdout, '', 0)
 
     def test_ls_wildcard(self):
         self._authorize_account()
         self._create_my_bucket()
 
         # Check with no files
-        self._run_command(['ls', 'my-bucket', '**/*.txt'], '', '', 1)
+        self._run_command(['ls', '--withWildcard', 'my-bucket', '*.txt'], '', '', 1)
 
         # Create some files, including files in a folder
         bucket = self.b2_api.get_bucket_by_name('my-bucket')
@@ -2156,7 +2157,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         c/test.tsv
         '''
         self._run_command(
-            ['ls', 'my-bucket', '**/*.[tc]sv'],
+            ['ls', '--withWildcard', 'my-bucket', '**/*.[tc]sv'],
             expected_stdout,
         )
 
@@ -2166,7 +2167,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         c/test.tsv
         '''
         self._run_command(
-            ['ls', 'my-bucket', '**/*.tsv'],
+            ['ls', '--withWildcard', 'my-bucket', '**/*.tsv'],
             expected_stdout,
         )
 
@@ -2174,7 +2175,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         b/b1/test.csv
         '''
         self._run_command(
-            ['ls', 'my-bucket', 'b/b?/test.csv'],
+            ['ls', '--withWildcard', 'my-bucket', 'b/b?/test.csv'],
             expected_stdout,
         )
 
@@ -2185,7 +2186,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         c/test.tsv
         '''
         self._run_command(
-            ['ls', 'my-bucket', '?/test.?sv'],
+            ['ls', '--withWildcard', 'my-bucket', '?/test.?sv'],
             expected_stdout,
         )
 
@@ -2194,7 +2195,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         b/b1/test.csv
         '''
         self._run_command(
-            ['ls', 'my-bucket', '?/*/*.[!t]sv'],
+            ['ls', '--withWildcard', 'my-bucket', '?/*/*.[!t]sv'],
             expected_stdout,
         )
 
@@ -2510,7 +2511,8 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         b/test.txt
         c/test.tsv
         '''
-        self._run_command(['ls', 'my-bucket'], expected_stdout)
+        # TODO B2-13 - replace with `find` command
+        self._run_command(['ls', '--withWildcard', 'my-bucket', '**'], expected_stdout)
 
     def test_rm_versions(self):
         # Uploading content of the bucket again to create second version of each file.
@@ -2530,7 +2532,10 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         c/test.tsv
         c/test.tsv
         '''
-        self._run_command(['ls', '--versions', 'my-bucket'], expected_stdout)
+        # TODO B2-13 replace with `find` command
+        self._run_command(
+            ['ls', '--withWildcard', '--versions', 'my-bucket', '**'], expected_stdout
+        )
 
     def test_rm_no_recursive(self):
         self._run_command(['rm', '--noProgress', 'my-bucket', 'b/'])
@@ -2541,7 +2546,8 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         c/test.csv
         c/test.tsv
         '''
-        self._run_command(['ls', 'my-bucket'], expected_stdout)
+        # TODO B2-13 replace with `find` command
+        self._run_command(['ls', '--withWildcard', 'my-bucket', '**'], expected_stdout)
 
     def test_rm_dry_run(self):
         expected_stdout = '''
@@ -2565,7 +2571,8 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         c/test.csv
         c/test.tsv
         '''
-        self._run_command(['ls', 'my-bucket', '**'], expected_stdout)
+        # TODO B2-13 replace with `find` command
+        self._run_command(['ls', '--withWildcard', 'my-bucket', '**'], expected_stdout)
 
     def test_rm_exact_filename(self):
         self._run_command(
@@ -2581,7 +2588,8 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         c/test.csv
         c/test.tsv
         '''
-        self._run_command(['ls', 'my-bucket', '**'], expected_stdout)
+        # TODO B2-13 replace with `find` command
+        self._run_command(['ls', '--withWildcard', 'my-bucket', '**'], expected_stdout)
 
     def test_rm_no_name_removes_everything(self):
         self._run_command(['rm', '--recursive', '--noProgress', 'my-bucket'])
@@ -2611,7 +2619,8 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         b/test.txt
         c/test.tsv
         '''
-        self._run_command(['ls', 'my-bucket', '**'], expected_stdout)
+        # TODO B2-13 replace with `find` command
+        self._run_command(['ls', '--withWildcard', 'my-bucket', '**'], expected_stdout)
 
     def _run_problematic_removal(
         self,
@@ -2666,4 +2675,5 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         expected_stdout = '''
         b/b1/test.csv
         '''
-        self._run_command(['ls', 'my-bucket', '**'], expected_stdout)
+        # TODO B2-13 replace with `find` command
+        self._run_command(['ls', '--withWildcard', 'my-bucket', '**'], expected_stdout)

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -2140,7 +2140,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         self._create_my_bucket()
 
         # Check with no files
-        self._run_command(['ls', 'my-bucket', '*.txt'], '', '', 0)
+        self._run_command(['ls', 'my-bucket', '**/*.txt'], '', '', 1)
 
         # Create some files, including files in a folder
         bucket = self.b2_api.get_bucket_by_name('my-bucket')
@@ -2156,7 +2156,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         c/test.tsv
         '''
         self._run_command(
-            ['ls', 'my-bucket', '*.[tc]sv'],
+            ['ls', 'my-bucket', '**/*.[tc]sv'],
             expected_stdout,
         )
 
@@ -2166,7 +2166,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         c/test.tsv
         '''
         self._run_command(
-            ['ls', 'my-bucket', '*.tsv'],
+            ['ls', 'my-bucket', '**/*.tsv'],
             expected_stdout,
         )
 
@@ -2565,7 +2565,7 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         c/test.csv
         c/test.tsv
         '''
-        self._run_command(['ls', 'my-bucket'], expected_stdout)
+        self._run_command(['ls', 'my-bucket', '**'], expected_stdout)
 
     def test_rm_exact_filename(self):
         self._run_command(
@@ -2581,7 +2581,7 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         c/test.csv
         c/test.tsv
         '''
-        self._run_command(['ls', 'my-bucket'], expected_stdout)
+        self._run_command(['ls', 'my-bucket', '**'], expected_stdout)
 
     def test_rm_no_name_removes_everything(self):
         self._run_command(['rm', '--recursive', '--noProgress', 'my-bucket'])
@@ -2611,7 +2611,7 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         b/test.txt
         c/test.tsv
         '''
-        self._run_command(['ls', 'my-bucket'], expected_stdout)
+        self._run_command(['ls', 'my-bucket', '**'], expected_stdout)
 
     def _run_problematic_removal(
         self,
@@ -2666,4 +2666,4 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         expected_stdout = '''
         b/b1/test.csv
         '''
-        self._run_command(['ls', 'my-bucket'], expected_stdout)
+        self._run_command(['ls', 'my-bucket', '**'], expected_stdout)

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -2133,14 +2133,14 @@ class TestConsoleTool(BaseConsoleToolTest):
                                                                                        9995  upload  1970-01-01  00:00:05          6  c
                                                                                        9996  upload  1970-01-01  00:00:05          5  c
         '''
-        self._run_command(['ls', '--long', '--versions', 'my-bucket'], expected_stdout, '', 0)
+        self._run_command(['ls', '-l', '--versions', 'my-bucket'], expected_stdout, '', 0)
 
     def test_ls_wildcard(self):
         self._authorize_account()
         self._create_my_bucket()
 
         # Check with no files
-        self._run_command(['ls', '--recursive', '--withWildcard', 'my-bucket', '*.txt'], '', '', 0)
+        self._run_command(['ls', 'my-bucket', '*.txt'], '', '', 0)
 
         # Create some files, including files in a folder
         bucket = self.b2_api.get_bucket_by_name('my-bucket')
@@ -2156,7 +2156,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         c/test.tsv
         '''
         self._run_command(
-            ['ls', '--recursive', '--withWildcard', 'my-bucket', '*.[tc]sv'],
+            ['ls', 'my-bucket', '*.[tc]sv'],
             expected_stdout,
         )
 
@@ -2166,7 +2166,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         c/test.tsv
         '''
         self._run_command(
-            ['ls', '--recursive', '--withWildcard', 'my-bucket', '*.tsv'],
+            ['ls', 'my-bucket', '*.tsv'],
             expected_stdout,
         )
 
@@ -2174,7 +2174,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         b/b1/test.csv
         '''
         self._run_command(
-            ['ls', '--recursive', '--withWildcard', 'my-bucket', 'b/b?/test.csv'],
+            ['ls', 'my-bucket', 'b/b?/test.csv'],
             expected_stdout,
         )
 
@@ -2185,7 +2185,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         c/test.tsv
         '''
         self._run_command(
-            ['ls', '--recursive', '--withWildcard', 'my-bucket', '?/test.?sv'],
+            ['ls', 'my-bucket', '?/test.?sv'],
             expected_stdout,
         )
 
@@ -2194,19 +2194,8 @@ class TestConsoleTool(BaseConsoleToolTest):
         b/b1/test.csv
         '''
         self._run_command(
-            ['ls', '--recursive', '--withWildcard', 'my-bucket', '?/*/*.[!t]sv'],
+            ['ls', 'my-bucket', '?/*/*.[!t]sv'],
             expected_stdout,
-        )
-
-    def test_ls_with_wildcard_no_recursive(self):
-        self._authorize_account()
-        self._create_my_bucket()
-
-        # Check with no files
-        self._run_command(
-            ['ls', '--withWildcard', 'my-bucket'],
-            expected_stderr='ERROR: with_wildcard requires recursive to be turned on as well\n',
-            expected_status=1,
         )
 
     def test_restrictions(self):
@@ -2443,7 +2432,6 @@ class TestConsoleToolWithV1(BaseConsoleToolTest):
         self._run_command(['list-parts', file.file_id], '', '', 0)
 
     def test_list_parts_with_parts(self):
-
         bucket = self.b2_api.get_bucket_by_name('my-bucket')
         file = self.v1_bucket.start_large_file('file', 'text/plain', {})
         content = b'hello world'
@@ -2522,7 +2510,7 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         b/test.txt
         c/test.tsv
         '''
-        self._run_command(['ls', '--recursive', 'my-bucket'], expected_stdout)
+        self._run_command(['ls', 'my-bucket'], expected_stdout)
 
     def test_rm_versions(self):
         # Uploading content of the bucket again to create second version of each file.
@@ -2542,7 +2530,7 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         c/test.tsv
         c/test.tsv
         '''
-        self._run_command(['ls', '--versions', '--recursive', 'my-bucket'], expected_stdout)
+        self._run_command(['ls', '--versions', 'my-bucket'], expected_stdout)
 
     def test_rm_no_recursive(self):
         self._run_command(['rm', '--noProgress', 'my-bucket', 'b/'])
@@ -2553,7 +2541,7 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         c/test.csv
         c/test.tsv
         '''
-        self._run_command(['ls', '--recursive', 'my-bucket'], expected_stdout)
+        self._run_command(['ls', 'my-bucket'], expected_stdout)
 
     def test_rm_dry_run(self):
         expected_stdout = '''
@@ -2577,7 +2565,7 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         c/test.csv
         c/test.tsv
         '''
-        self._run_command(['ls', '--recursive', 'my-bucket'], expected_stdout)
+        self._run_command(['ls', 'my-bucket'], expected_stdout)
 
     def test_rm_exact_filename(self):
         self._run_command(
@@ -2593,11 +2581,11 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         c/test.csv
         c/test.tsv
         '''
-        self._run_command(['ls', '--recursive', 'my-bucket'], expected_stdout)
+        self._run_command(['ls', 'my-bucket'], expected_stdout)
 
     def test_rm_no_name_removes_everything(self):
         self._run_command(['rm', '--recursive', '--noProgress', 'my-bucket'])
-        self._run_command(['ls', '--recursive', 'my-bucket'], '')
+        self._run_command(['ls', 'my-bucket'], '')
 
     def test_rm_with_wildcard_without_recursive(self):
         self._run_command(
@@ -2608,7 +2596,7 @@ class TestRmConsoleTool(BaseConsoleToolTest):
 
     def test_rm_queue_size_and_number_of_threads(self):
         self._run_command(['rm', '--recursive', '--threads', '2', '--queueSize', '4', 'my-bucket'])
-        self._run_command(['ls', '--recursive', 'my-bucket'], '')
+        self._run_command(['ls', 'my-bucket'], '')
 
     def test_rm_progress(self):
         expected_in_stdout = ' count: 4/4 '
@@ -2623,7 +2611,7 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         b/test.txt
         c/test.tsv
         '''
-        self._run_command(['ls', '--recursive', 'my-bucket'], expected_stdout)
+        self._run_command(['ls', 'my-bucket'], expected_stdout)
 
     def _run_problematic_removal(
         self,
@@ -2678,4 +2666,4 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         expected_stdout = '''
         b/b1/test.csv
         '''
-        self._run_command(['ls', '--recursive', 'my-bucket'], expected_stdout)
+        self._run_command(['ls', 'my-bucket'], expected_stdout)

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -2116,7 +2116,7 @@ class TestConsoleTool(BaseConsoleToolTest):
         b/b2
         c
         '''
-        self._run_command(['ls', '--recursive', 'my-bucket'], expected_stdout, '', 0)
+        self._run_command(['ls', 'my-bucket', '**'], expected_stdout, '', 0)
 
         # Check long output.   (The format expects full-length file ids, so it causes whitespace here)
         expected_stdout = '''


### PR DESCRIPTION
requires https://github.com/reef-technologies/b2-sdk-python/pull/302 to be merged first

Since this task is quite big, I split it into multiple PRs

## Changes `ls`
- Drop `--recursive` option in `b2 ls`.
- Make `b2 ls` show an error and exit with non-0 status code if the directory doesn’t exist.
- Allow `*`, `**`, `?` ,`[]` ,`{}` globs/patterns in `b2 ls`,  globbing should work similarly to bash globs. Allow escaping special symbols with backslash `\`.
- Allow using more conventional `-l` flags with `b2 ls`


## Changes `rm`
- Make `b2 rm` show an error and exit with non-0 status code if the directory doesn’t exist.
- Allow using more conventional `-r`, with `b2 rm`.
- Allow `*`, `**`, `?`, `[]` ,`{}` globs/patterns in `b2 rm`, globbing should work similarly to bash globs. Allow escaping special symbols with backslash `\`.
