### PR TITLE
Fix b2 uri containing ? or #

### DIFF
--- a/changelog.d/+b2uri-special-characters.fixed.md
+++ b/changelog.d/+b2uri-special-characters.fixed.md
@@ -1,0 +1,1 @@
+Fixed special characters `?` and `#` in b2uri causing incorrect parsing of the URI.

--- a/test/unit/_utils/test_uri.py
+++ b/test/unit/_utils/test_uri.py
@@ -66,6 +66,9 @@ def test_b2fileuri_str():
         ("./some/local/path", Path("some/local/path")),
         ("b2://bucket/path/to/dir/", B2URI(bucket_name="bucket", path="path/to/dir/")),
         ("b2id://file123", B2FileIdURI(file_id="file123")),
+        ("b2://bucket/wild[card]", B2URI(bucket_name="bucket", path="wild[card]")),
+        ("b2://bucket/wild?card", B2URI(bucket_name="bucket", path="wild?card")),
+        ("b2://bucket/special#char", B2URI(bucket_name="bucket", path="special#char")),
     ],
 )
 def test_parse_uri(uri, expected):


### PR DESCRIPTION
To support wildcards in `ls` and `rm` URIs, this PR prepares b2uri parsing to account for `?` and `#` characters in URI paths.