### PR TITLE
Fix non-recursive rm deleting files in subdirectories

### DIFF
--- a/b2/_internal/console_tool.py
+++ b/b2/_internal/console_tool.py
@@ -2405,7 +2405,11 @@ class BaseRm(ThreadsMixin, AbstractLsCommand, metaclass=ABCMeta):
                 self.messages_queue.put(self.END_MARKER)
 
         def _run_removal(self, executor: Executor):
-            for file_version, _ in self.runner._get_ls_generator(self.args):
+            for file_version, subdirectory in self.runner._get_ls_generator(self.args):
+                if subdirectory is not None:
+                    # This file_version is not for listing/deleting.
+                    # It is only here to list the subdirectory, so skip deleting it.
+                    continue
                 # Obtaining semaphore limits number of elements that we fetch from LS.
                 self.semaphore.acquire(blocking=True)
                 # This event is updated before the semaphore is released. This way,

--- a/changelog.d/+fix-rm-non-recursive.fixed.md
+++ b/changelog.d/+fix-rm-non-recursive.fixed.md
@@ -1,0 +1,2 @@
+Fixed a bug where `rm` command without the `--recursive` flag would
+remove a file from every subdirectory inside `folderName`.

--- a/changelog.d/+fix-rm-non-recursive.fixed.md
+++ b/changelog.d/+fix-rm-non-recursive.fixed.md
@@ -1,2 +1,2 @@
-Fixed a bug where `rm` command without the `--recursive` flag would
+Fixed a bug where `rm bucketName folderName` command without the `--recursive` flag would
 remove a file from every subdirectory inside `folderName`.

--- a/test/unit/test_console_tool.py
+++ b/test/unit/test_console_tool.py
@@ -2599,6 +2599,9 @@ class TestRmConsoleTool(BaseConsoleToolTest):
         expected_stdout = '''
         a/test.csv
         a/test.tsv
+        b/b/test.csv
+        b/b1/test.csv
+        b/b2/test.tsv
         c/test.csv
         c/test.tsv
         '''


### PR DESCRIPTION
Running `b2 rm myBucket folder` should delete everything directly in `folder` but, should not delete in files in the the subdirectories of `folder`.

The bug makes the above command delete the first file from every subdirectory under `folder`.