### PR TITLE
B2-119 Make persistent test buckets auto-clean files

### DIFF
--- a/changelog.d/+deleting_used_files_in_testing.infrastructure.md
+++ b/changelog.d/+deleting_used_files_in_testing.infrastructure.md
@@ -1,0 +1,1 @@
+Deleting used files by integration tests right away.

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -423,7 +423,7 @@ def b2_uri_args(apiver_int):
         return b2_uri_args_v3
 
 
-# -- Persistent bucket code --
+# -- Persistent bucket code ---
 
 subfolder_list: list[str] = []
 

--- a/test/integration/persistent_bucket.py
+++ b/test/integration/persistent_bucket.py
@@ -62,3 +62,6 @@ def get_or_create_persistent_bucket(b2_api: Api) -> Bucket:
     # add the new bucket name to the list of bucket names
     b2_api.bucket_name_log.append(bucket_name)
     return bucket
+
+def prune_used_files(b2_api: Api, bucket: Bucket, folders: list[str]):
+    b2_api.clean_bucket(bucket_object=bucket, only_files=True, only_folders=folders,ignore_retentions=True)

--- a/test/integration/persistent_bucket.py
+++ b/test/integration/persistent_bucket.py
@@ -11,6 +11,7 @@ import hashlib
 import os
 from dataclasses import dataclass
 from functools import cached_property
+from typing import List
 
 import backoff
 from b2sdk.v2 import Bucket
@@ -63,5 +64,5 @@ def get_or_create_persistent_bucket(b2_api: Api) -> Bucket:
     b2_api.bucket_name_log.append(bucket_name)
     return bucket
 
-def prune_used_files(b2_api: Api, bucket: Bucket, folders: list[str]):
+def prune_used_files(b2_api: Api, bucket: Bucket, folders: List[str]):
     b2_api.clean_bucket(bucket_object=bucket, only_files=True, only_folders=folders,ignore_retentions=True)


### PR DESCRIPTION
Builds on previous work with Persistent Buckets. This now keeps track of used folders in the persistent bucket and cleans files without having to wait for B2's lifecycle rules.

- used random folder generation to track used files through testing sessions
- extended clean_files function to allow for cleaning some folders from a bucket without deleting it