### PR TITLE
fix multi bucket restrictions integration test

### DIFF
--- a/changelog.d/+fix-multi-bucket-key-integration-test.infrastructure.md
+++ b/changelog.d/+fix-multi-bucket-key-integration-test.infrastructure.md
@@ -1,0 +1,1 @@
+Fix flaky integration test for multi-bucket key restrictions.

--- a/test/integration/test_b2_command_line.py
+++ b/test/integration/test_b2_command_line.py
@@ -815,8 +815,21 @@ def test_multi_bucket_key_restrictions(b2_tool, bucket_factory):
         ['bucket', 'get', bucket_b.name],
     )
 
-    failed_bucket_err = rf"ERROR: Application key is restricted to buckets: \['{bucket_a.name}', '{bucket_b.name}'\]"
+    failed_bucket_err = rf"ERROR: Application key is restricted to buckets: \['{bucket_a.name}', '{bucket_b.name}'|'{bucket_b.name}', '{bucket_a.name}'\]"
+
     b2_tool.should_fail(['bucket', 'get', bucket_c.name], failed_bucket_err)
+
+    # reauthorize with more capabilities for clean up
+    b2_tool.should_succeed(
+        [
+            'account',
+            'authorize',
+            '--environment',
+            b2_tool.realm,
+            b2_tool.account_id,
+            b2_tool.application_key,
+        ]
+    )
 
     b2_tool.should_succeed(['key', 'delete', mb_key_id])
 


### PR DESCRIPTION
- **Add multi-bucket key support in key create subcommand**
- **Support multi-bucket-keys in key list subcommand**
- **Replace deprecated windows-2019 ci image with windows-2025**
- **Fix order issue in multi-bucket key restrictions test**
